### PR TITLE
Fix ReadPointer for x64

### DIFF
--- a/FFXIVAPP.Memory/MemoryHandler.cs
+++ b/FFXIVAPP.Memory/MemoryHandler.cs
@@ -253,7 +253,7 @@ namespace FFXIVAPP.Memory
             {
                 var win64 = new byte[8];
                 Peek(new IntPtr(address.ToInt64() + offset), win64);
-                return IntPtr.Add(address, (int) BitConverter.ToInt64(win64, 0));
+                return IntPtr.Add(IntPtr.Zero, (int)BitConverter.ToInt64(win64, 0));
             }
             var win32 = new byte[4];
             Peek(new IntPtr(address.ToInt64() + offset), win32);


### PR DESCRIPTION
ReadPointer would end up mangling pointers with low addresses, most usually CHATLOG. Revert it to what it was before.