### PR TITLE
Generalise increment for the address variable

### DIFF
--- a/FFXIVAPP.Memory/Scanner.cs
+++ b/FFXIVAPP.Memory/Scanner.cs
@@ -105,7 +105,19 @@ namespace FFXIVAPP.Memory
                     {
                         MemoryHandler.Instance.RaiseException(Logger, new Exception(info.ToString()));
                     }
-                    address = IntPtr.Add(info.BaseAddress, info.RegionSize.ToInt32());
+                    //address = IntPtr.Add(info.BaseAddress, info.RegionSize.ToInt32());
+                    unchecked
+                    {
+                        switch (IntPtr.Size)
+                        {
+                            case sizeof(int):
+                                address = new IntPtr(info.BaseAddress.ToInt32() + info.RegionSize.ToInt32());
+                                break;
+                            default:
+                                address = new IntPtr(info.BaseAddress.ToInt64() + info.RegionSize.ToInt64());
+                                break;
+                        }
+                    }
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
Generalise the increment for the address variable as to not throw a "Arithmetic operation resulted in an overflow" exception when using 64-bit values.