### PR TITLE
adjust limit for looping the character list

### DIFF
--- a/Sharlayan/Reader.Actor.cs
+++ b/Sharlayan/Reader.Actor.cs
@@ -48,7 +48,7 @@ namespace Sharlayan
 
                 var endianSize = MemoryHandler.Instance.ProcessModel.IsWin64 ? 8 : 4;
 
-                const int limit = 1372;
+                const int limit = 424;
 
                 var characterAddressMap = MemoryHandler.Instance.GetByteArray(Scanner.Instance.Locations["CHARMAP"], endianSize * limit);
                 var uniqueAddresses = new Dictionary<IntPtr, IntPtr>();


### PR DESCRIPTION
424 is the value the game uses
also removes "ghost" entities to appear on radar, like NPCs outside the map and things with names like "�@�"