### PR TITLE
Bug fixes

### DIFF
--- a/Sharlayan.sln
+++ b/Sharlayan.sln
@@ -20,7 +20,9 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{9510D5EF-208A-4897-A582-8EAE5C6E9406}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{9510D5EF-208A-4897-A582-8EAE5C6E9406}.Debug|Any CPU.Build.0 = Debug|x86
 		{9510D5EF-208A-4897-A582-8EAE5C6E9406}.Release|Any CPU.ActiveCfg = Release|x86
+		{9510D5EF-208A-4897-A582-8EAE5C6E9406}.Release|Any CPU.Build.0 = Release|x86
 		{FCAD4340-866B-4153-8A55-311224B764F6}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{FCAD4340-866B-4153-8A55-311224B764F6}.Debug|Any CPU.Build.0 = Debug|x86
 		{FCAD4340-866B-4153-8A55-311224B764F6}.Release|Any CPU.ActiveCfg = Release|x86

--- a/Sharlayan/Core/ActorItem.cs
+++ b/Sharlayan/Core/ActorItem.cs
@@ -164,5 +164,14 @@ namespace Sharlayan.Core {
 
             return cloned;
         }
+
+        public override float GetCastingDistanceTo(ActorItem compare)
+        {
+            var distance = this.GetHorizontalDistanceTo(compare) - compare.HitBoxRadius - HitBoxRadius;
+            return distance > 0
+                       ? distance
+                       : 0;
+        }
+
     }
 }

--- a/Sharlayan/Core/ActorItem.cs
+++ b/Sharlayan/Core/ActorItem.cs
@@ -135,10 +135,10 @@ namespace Sharlayan.Core {
 
         public ActorItem Clone() {
             var cloned = (ActorItem) this.MemberwiseClone();
-
+            
             cloned.Coordinate = new Coordinate(this.Coordinate.X, this.Coordinate.Z, this.Coordinate.Y);
-            cloned.EnmityItems.Clear();
-            cloned.StatusItems.Clear();
+            cloned.EnmityItems = new System.Collections.Generic.List<EnmityItem>();
+            cloned.StatusItems = new System.Collections.Generic.List<StatusItem>();
 
             foreach (EnmityItem item in this.EnmityItems) {
                 cloned.EnmityItems.Add(

--- a/Sharlayan/Core/ActorItem.cs
+++ b/Sharlayan/Core/ActorItem.cs
@@ -58,9 +58,7 @@ namespace Sharlayan.Core {
         public byte GrandCompanyRank { get; set; }
 
         public float Heading { get; set; }
-
-        public float HitBoxRadius { get; set; }
-
+        
         public Actor.Icon Icon { get; set; }
 
         public byte IconID { get; set; }
@@ -164,14 +162,6 @@ namespace Sharlayan.Core {
 
             return cloned;
         }
-
-        public override float GetCastingDistanceTo(ActorItem compare)
-        {
-            var distance = this.GetHorizontalDistanceTo(compare) - compare.HitBoxRadius - HitBoxRadius;
-            return distance > 0
-                       ? distance
-                       : 0;
-        }
-
+        
     }
 }

--- a/Sharlayan/Core/ActorItemBase.cs
+++ b/Sharlayan/Core/ActorItemBase.cs
@@ -100,7 +100,7 @@ namespace Sharlayan.Core {
 
         public double Z { get; set; }
 
-        public float GetCastingDistanceTo(ActorItem compare) {
+        public virtual float GetCastingDistanceTo(ActorItem compare) {
             var distance = this.GetHorizontalDistanceTo(compare) - compare.HitBoxRadius;
             return distance > 0
                        ? distance

--- a/Sharlayan/Core/ActorItemBase.cs
+++ b/Sharlayan/Core/ActorItemBase.cs
@@ -31,7 +31,7 @@ namespace Sharlayan.Core {
 
         public string CPString => $"{this.CPCurrent}/{this.CPMax} [{this.CPPercent:P2}]";
 
-        public List<EnmityItem> EnmityItems { get; } = new List<EnmityItem>();
+        public List<EnmityItem> EnmityItems { get; set; } = new List<EnmityItem>();
 
         public short GPCurrent { get; set; }
 
@@ -79,7 +79,7 @@ namespace Sharlayan.Core {
             set => this._name = value.ToTitleCase();
         }
 
-        public List<StatusItem> StatusItems { get; } = new List<StatusItem>();
+        public List<StatusItem> StatusItems { get; set; } = new List<StatusItem>();
 
         public int TPCurrent { get; set; }
 

--- a/Sharlayan/Core/ActorItemBase.cs
+++ b/Sharlayan/Core/ActorItemBase.cs
@@ -44,6 +44,8 @@ namespace Sharlayan.Core {
 
         public string GPString => $"{this.GPCurrent}/{this.GPMax} [{this.GPPercent:P2}]";
 
+        public float HitBoxRadius { get; set; }
+
         public int HPCurrent { get; set; }
 
         public int HPMax { get; set; }
@@ -100,8 +102,9 @@ namespace Sharlayan.Core {
 
         public double Z { get; set; }
 
-        public virtual float GetCastingDistanceTo(ActorItem compare) {
-            var distance = this.GetHorizontalDistanceTo(compare) - compare.HitBoxRadius;
+        public float GetCastingDistanceTo(ActorItem compare)
+        {
+            var distance = this.GetHorizontalDistanceTo(compare) - compare.HitBoxRadius - HitBoxRadius;
             return distance > 0
                        ? distance
                        : 0;

--- a/Sharlayan/Core/ActorItemBase.cs
+++ b/Sharlayan/Core/ActorItemBase.cs
@@ -24,10 +24,7 @@ namespace Sharlayan.Core {
 
         public short CPMax { get; set; }
 
-        public double CPPercent =>
-            (double) (this.CPMax == 0
-                          ? 0
-                          : decimal.Divide(this.CPCurrent, this.CPMax));
+        public double CPPercent => safeDivide(this.CPCurrent, this.CPMax);
 
         public string CPString => $"{this.CPCurrent}/{this.CPMax} [{this.CPPercent:P2}]";
 
@@ -37,10 +34,7 @@ namespace Sharlayan.Core {
 
         public short GPMax { get; set; }
 
-        public double GPPercent =>
-            (double) (this.GPMax == 0
-                          ? 0
-                          : decimal.Divide(this.GPCurrent, this.GPMax));
+        public double GPPercent => safeDivide(this.GPCurrent, this.GPMax);
 
         public string GPString => $"{this.GPCurrent}/{this.GPMax} [{this.GPPercent:P2}]";
 
@@ -50,10 +44,7 @@ namespace Sharlayan.Core {
 
         public int HPMax { get; set; }
 
-        public double HPPercent =>
-            (double) (this.HPMax == 0
-                          ? 0
-                          : decimal.Divide(this.HPCurrent, this.HPMax));
+        public double HPPercent => safeDivide(this.HPCurrent, this.HPMax);
 
         public string HPString => $"{this.HPCurrent}/{this.HPMax} [{this.HPPercent:P2}]";
 
@@ -69,10 +60,7 @@ namespace Sharlayan.Core {
 
         public int MPMax { get; set; }
 
-        public double MPPercent =>
-            (double) (this.MPMax == 0
-                          ? 0
-                          : decimal.Divide(this.MPCurrent, this.MPMax));
+        public double MPPercent => safeDivide(this.MPCurrent, this.MPMax);
 
         public string MPString => $"{this.MPCurrent}/{this.MPMax} [{this.MPPercent:P2}]";
 
@@ -87,10 +75,7 @@ namespace Sharlayan.Core {
 
         public int TPMax { get; set; }
 
-        public double TPPercent =>
-            (double) (this.TPMax == 0
-                          ? 0
-                          : decimal.Divide(this.TPCurrent, this.TPMax));
+        public double TPPercent => safeDivide(this.TPCurrent, this.TPMax);
 
         public string TPString => $"{this.TPCurrent}/{this.TPMax} [{this.TPPercent:P2}]";
 
@@ -101,6 +86,22 @@ namespace Sharlayan.Core {
         public double Y { get; set; }
 
         public double Z { get; set; }
+
+        private double safeDivide(double a, double b)
+        {
+            try
+            {
+                if (b == 0)
+                    return 0;
+
+                return a / b;
+            }
+            catch
+            {
+                // due to multithreading, sometimes b can be set to 0 between the check and the division
+                return 0;
+            }
+        }
 
         public float GetCastingDistanceTo(ActorItem compare)
         {

--- a/Sharlayan/Core/ActorItemBase.cs
+++ b/Sharlayan/Core/ActorItemBase.cs
@@ -31,7 +31,7 @@ namespace Sharlayan.Core {
 
         public string CPString => $"{this.CPCurrent}/{this.CPMax} [{this.CPPercent:P2}]";
 
-        public List<EnmityItem> EnmityItems { get; set; } = new List<EnmityItem>();
+        public List<EnmityItem> EnmityItems { get; protected set; } = new List<EnmityItem>();
 
         public short GPCurrent { get; set; }
 
@@ -79,7 +79,7 @@ namespace Sharlayan.Core {
             set => this._name = value.ToTitleCase();
         }
 
-        public List<StatusItem> StatusItems { get; set; } = new List<StatusItem>();
+        public List<StatusItem> StatusItems { get; protected set; } = new List<StatusItem>();
 
         public int TPCurrent { get; set; }
 

--- a/Sharlayan/Core/PartyMember.cs
+++ b/Sharlayan/Core/PartyMember.cs
@@ -18,8 +18,8 @@ namespace Sharlayan.Core {
             var cloned = (PartyMember) this.MemberwiseClone();
 
             cloned.Coordinate = new Coordinate(this.Coordinate.X, this.Coordinate.Z, this.Coordinate.Y);
-            cloned.EnmityItems.Clear();
-            cloned.StatusItems.Clear();
+            cloned.EnmityItems = new System.Collections.Generic.List<EnmityItem>();
+            cloned.StatusItems = new System.Collections.Generic.List<StatusItem>();
 
             foreach (EnmityItem item in this.EnmityItems) {
                 cloned.EnmityItems.Add(

--- a/Sharlayan/Models/Structures/StatusItem.cs
+++ b/Sharlayan/Models/Structures/StatusItem.cs
@@ -10,6 +10,9 @@
 
 namespace Sharlayan.Models.Structures {
     public class StatusItem {
+        
+        public int SourceSize { get; set; }
+        
         public int CasterID { get; set; }
 
         public int Duration { get; set; }

--- a/Sharlayan/Reader.CurrentPlayer.cs
+++ b/Sharlayan/Reader.CurrentPlayer.cs
@@ -38,7 +38,19 @@ namespace Sharlayan {
                 return result;
             }
 
-            try {
+            try
+            {
+                byte[] source = MemoryHandler.Instance.GetByteArray(PlayerInfoMap, MemoryHandler.Instance.Structures.CurrentPlayer.SourceSize);
+
+                try
+                {
+                    result.CurrentPlayer = CurrentPlayerResolver.ResolvePlayerFromBytes(source);
+                }
+                catch (Exception ex)
+                {
+                    MemoryHandler.Instance.RaiseException(Logger, ex, true);
+                }
+
                 if (CanGetAgroEntities()) {
                     var agroCount = MemoryHandler.Instance.GetInt16(Scanner.Instance.Locations[Signatures.AgroCountKey]);
                     var agroStructure = (IntPtr) Scanner.Instance.Locations[Signatures.AgroMapKey];
@@ -59,14 +71,6 @@ namespace Sharlayan {
                     }
                 }
 
-                byte[] source = MemoryHandler.Instance.GetByteArray(PlayerInfoMap, MemoryHandler.Instance.Structures.CurrentPlayer.SourceSize);
-
-                try {
-                    result.CurrentPlayer = CurrentPlayerResolver.ResolvePlayerFromBytes(source);
-                }
-                catch (Exception ex) {
-                    MemoryHandler.Instance.RaiseException(Logger, ex, true);
-                }
             }
             catch (Exception ex) {
                 MemoryHandler.Instance.RaiseException(Logger, ex, true);

--- a/Sharlayan/Reader.PartyMembers.cs
+++ b/Sharlayan/Reader.PartyMembers.cs
@@ -86,7 +86,7 @@ namespace Sharlayan {
                     }
                 }
 
-                if (partyCount == 1) {
+                if (partyCount <= 1) {
                     PartyMember entry = PartyMemberResolver.ResolvePartyMemberFromBytes(Array.Empty<byte>(), PCWorkerDelegate.CurrentUser);
                     if (result.RemovedPartyMembers.ContainsKey(entry.ID)) {
                         result.RemovedPartyMembers.TryRemove(entry.ID, out PartyMember removedPartyMember);

--- a/Sharlayan/Utilities/ActorItemResolver.cs
+++ b/Sharlayan/Utilities/ActorItemResolver.cs
@@ -123,7 +123,7 @@ namespace Sharlayan.Utilities {
                         break;
                 }
 
-                const int statusSize = 12;
+                int statusSize = MemoryHandler.Instance.Structures.StatusItem.SourceSize;
                 byte[] statusesSource = new byte[limit * statusSize];
 
                 List<StatusItem> foundStatuses = new List<StatusItem>();

--- a/Sharlayan/Utilities/ActorItemResolver.cs
+++ b/Sharlayan/Utilities/ActorItemResolver.cs
@@ -16,11 +16,14 @@ namespace Sharlayan.Utilities {
     using Sharlayan.Core;
     using Sharlayan.Core.Enums;
     using Sharlayan.Delegates;
+    using System.Linq;
+    using System.Collections.Generic;
 
     internal static class ActorItemResolver {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
-
-        public static ActorItem ResolveActorFromBytes(byte[] source, bool isCurrentUser = false, ActorItem entry = null) {
+        
+        public static ActorItem ResolveActorFromBytes(byte[] source, bool isCurrentUser = false, ActorItem entry = null)
+        {
             entry = entry ?? new ActorItem();
             var defaultBaseOffset = MemoryHandler.Instance.Structures.ActorItem.DefaultBaseOffset;
             var defaultStatOffset = MemoryHandler.Instance.Structures.ActorItem.DefaultStatOffset;
@@ -123,18 +126,36 @@ namespace Sharlayan.Utilities {
                 const int statusSize = 12;
                 byte[] statusesSource = new byte[limit * statusSize];
 
+                List<StatusItem> foundStatuses = new List<StatusItem>();
+
                 Buffer.BlockCopy(source, defaultStatusEffectOffset, statusesSource, 0, limit * statusSize);
                 for (var i = 0; i < limit; i++) {
+
+                    bool isNewStatus = false;
+
                     byte[] statusSource = new byte[statusSize];
                     Buffer.BlockCopy(statusesSource, i * statusSize, statusSource, 0, statusSize);
-                    var statusEntry = new StatusItem {
-                        TargetEntity = entry,
-                        TargetName = entry.Name,
-                        StatusID = BitConverter.TryToInt16(statusSource, MemoryHandler.Instance.Structures.StatusItem.StatusID),
-                        Stacks = statusSource[MemoryHandler.Instance.Structures.StatusItem.Stacks],
-                        Duration = BitConverter.TryToSingle(statusSource, MemoryHandler.Instance.Structures.StatusItem.Duration),
-                        CasterID = BitConverter.TryToUInt32(statusSource, MemoryHandler.Instance.Structures.StatusItem.CasterID)
-                    };
+
+                    short StatusID = BitConverter.TryToInt16(statusSource, MemoryHandler.Instance.Structures.StatusItem.StatusID);
+                    uint CasterID = BitConverter.TryToUInt32(statusSource, MemoryHandler.Instance.Structures.StatusItem.CasterID);
+
+                    var statusEntry = entry.StatusItems.FirstOrDefault(x => x.CasterID == CasterID && x.StatusID == StatusID);
+
+                    if (statusEntry == null)
+                    {
+                        statusEntry = new StatusItem();
+                        isNewStatus = true;
+                    }
+
+                    statusEntry.TargetEntity = entry;
+                    statusEntry.TargetName = entry.Name;
+                    statusEntry.StatusID = StatusID;
+                    statusEntry.Stacks = statusSource[MemoryHandler.Instance.Structures.StatusItem.Stacks];
+                    statusEntry.Duration = BitConverter.TryToSingle(statusSource, MemoryHandler.Instance.Structures.StatusItem.Duration);
+                    statusEntry.CasterID = CasterID;
+
+
+
                     try {
                         ActorItem pc = PCWorkerDelegate.GetActorItem(statusEntry.CasterID);
                         ActorItem npc = NPCWorkerDelegate.GetActorItem(statusEntry.CasterID);
@@ -176,9 +197,15 @@ namespace Sharlayan.Utilities {
                     }
 
                     if (statusEntry.IsValid()) {
-                        entry.StatusItems.Add(statusEntry);
+                        if (isNewStatus)
+                        {
+                            entry.StatusItems.Add(statusEntry);
+                        }
+                        foundStatuses.Add(statusEntry);
                     }
                 }
+                
+                entry.StatusItems.RemoveAll(x => !foundStatuses.Contains(x));
 
                 // handle empty names
                 if (string.IsNullOrEmpty(entry.Name)) {

--- a/Sharlayan/Utilities/PartyMemberResolver.cs
+++ b/Sharlayan/Utilities/PartyMemberResolver.cs
@@ -36,7 +36,8 @@ namespace Sharlayan.Utilities {
                     HPCurrent = actorItem.HPCurrent,
                     HPMax = actorItem.HPMax,
                     MPCurrent = actorItem.MPCurrent,
-                    MPMax = actorItem.MPMax
+                    MPMax = actorItem.MPMax,
+                    HitBoxRadius = actorItem.HitBoxRadius
                 };
                 entry.StatusItems.AddRange(actorItem.StatusItems);
                 CleanXPValue(ref entry);
@@ -55,6 +56,7 @@ namespace Sharlayan.Utilities {
                     entry.Name = MemoryHandler.Instance.GetStringFromBytes(source, MemoryHandler.Instance.Structures.PartyMember.Name);
                     entry.JobID = source[MemoryHandler.Instance.Structures.PartyMember.Job];
                     entry.Job = (Actor.Job) entry.JobID;
+                    entry.HitBoxRadius = 0.5f;
 
                     entry.Level = source[MemoryHandler.Instance.Structures.PartyMember.Level];
                     entry.HPCurrent = BitConverter.TryToInt32(source, MemoryHandler.Instance.Structures.PartyMember.HPCurrent);

--- a/Sharlayan/Utilities/PartyMemberResolver.cs
+++ b/Sharlayan/Utilities/PartyMemberResolver.cs
@@ -10,7 +10,8 @@
 
 namespace Sharlayan.Utilities {
     using System;
-
+    using System.Collections.Generic;
+    using System.Linq;
     using NLog;
 
     using Sharlayan.Core;
@@ -64,18 +65,40 @@ namespace Sharlayan.Utilities {
                     const int statusSize = 12;
                     byte[] statusesSource = new byte[limit * statusSize];
 
+                    List<StatusItem> foundStatuses = new List<StatusItem>();
+
                     Buffer.BlockCopy(source, defaultStatusEffectOffset, statusesSource, 0, limit * 12);
-                    for (var i = 0; i < limit; i++) {
+                    for (var i = 0; i < limit; i++)
+                    {
+                        bool isNewStatus = false;
+
                         byte[] statusSource = new byte[statusSize];
                         Buffer.BlockCopy(statusesSource, i * statusSize, statusSource, 0, statusSize);
-                        var statusEntry = new StatusItem {
-                            TargetName = entry.Name,
-                            StatusID = BitConverter.TryToInt16(statusSource, MemoryHandler.Instance.Structures.StatusItem.StatusID),
-                            Stacks = statusSource[MemoryHandler.Instance.Structures.StatusItem.Stacks],
-                            Duration = BitConverter.TryToSingle(statusSource, MemoryHandler.Instance.Structures.StatusItem.Duration),
-                            CasterID = BitConverter.TryToUInt32(statusSource, MemoryHandler.Instance.Structures.StatusItem.CasterID)
-                        };
-                        try {
+
+                        short StatusID = BitConverter.TryToInt16(statusSource, MemoryHandler.Instance.Structures.StatusItem.StatusID);
+                        uint CasterID = BitConverter.TryToUInt32(statusSource, MemoryHandler.Instance.Structures.StatusItem.CasterID);
+
+                        
+                        var statusEntry = entry.StatusItems.FirstOrDefault(x => x.CasterID == CasterID && x.StatusID == StatusID);
+
+                        if (statusEntry == null)
+                        {
+                            statusEntry = new StatusItem();
+                            isNewStatus = true;
+                        }
+
+                        statusEntry.TargetEntity = null;
+                        statusEntry.TargetName = entry.Name;
+                        statusEntry.StatusID = StatusID;
+                        statusEntry.Stacks = statusSource[MemoryHandler.Instance.Structures.StatusItem.Stacks];
+                        statusEntry.Duration = BitConverter.TryToSingle(statusSource, MemoryHandler.Instance.Structures.StatusItem.Duration);
+                        statusEntry.CasterID = CasterID;
+
+                        foundStatuses.Add(statusEntry);
+
+
+                        try
+                        {
                             ActorItem pc = PCWorkerDelegate.GetActorItem(statusEntry.CasterID);
                             ActorItem npc = NPCWorkerDelegate.GetActorItem(statusEntry.CasterID);
                             ActorItem monster = MonsterWorkerDelegate.GetActorItem(statusEntry.CasterID);
@@ -115,10 +138,18 @@ namespace Sharlayan.Utilities {
                             statusEntry.StatusName = "UNKNOWN";
                         }
 
-                        if (statusEntry.IsValid()) {
-                            entry.StatusItems.Add(statusEntry);
+                        if (statusEntry.IsValid())
+                        {
+                            if (isNewStatus)
+                            {
+                                entry.StatusItems.Add(statusEntry);
+                            }
+                            foundStatuses.Add(statusEntry);
                         }
                     }
+
+                    entry.StatusItems.RemoveAll(x => !foundStatuses.Contains(x));
+
                 }
                 catch (Exception ex) {
                     MemoryHandler.Instance.RaiseException(Logger, ex, true);

--- a/Sharlayan/Utilities/PartyMemberResolver.cs
+++ b/Sharlayan/Utilities/PartyMemberResolver.cs
@@ -64,12 +64,13 @@ namespace Sharlayan.Utilities {
                     entry.MPCurrent = BitConverter.TryToInt16(source, MemoryHandler.Instance.Structures.PartyMember.MPCurrent);
                     entry.MPMax = BitConverter.TryToInt16(source, MemoryHandler.Instance.Structures.PartyMember.MPMax);
                     const int limit = 15;
-                    const int statusSize = 12;
+
+                    int statusSize = MemoryHandler.Instance.Structures.StatusItem.SourceSize;
                     byte[] statusesSource = new byte[limit * statusSize];
 
                     List<StatusItem> foundStatuses = new List<StatusItem>();
 
-                    Buffer.BlockCopy(source, defaultStatusEffectOffset, statusesSource, 0, limit * 12);
+                    Buffer.BlockCopy(source, defaultStatusEffectOffset, statusesSource, 0, limit * statusSize);
                     for (var i = 0; i < limit; i++)
                     {
                         bool isNewStatus = false;


### PR DESCRIPTION
- Clone was clearing out the status entries of the original object.
- Fixing clone revealed a bug in status entries, which has also been fixed.
- PartyMembers should always have you in the list now.
- GetCastingDistanceTo should include the hitboxradius of both entities.
- CurrentPlayerResolver was overwriting agro.
- Actor items would sometimes be removed from the list and re-added the next tick, presumably due to concurrency issues with memory reading. Added a stale timeout prior to removing them.
- Division in some of the shared ActorItem auto properties was sometimes throwing exceptions due to multithreading. Fixed
- Status Effect structure size was still hardcoded. Moved to the structures api.