### PR TITLE
fix ProcessAccessFlags

### DIFF
--- a/Sharlayan/MemoryHandler.cs
+++ b/Sharlayan/MemoryHandler.cs
@@ -245,7 +245,7 @@ namespace Sharlayan {
             this.UnsetProcess();
 
             try {
-                this.ProcessHandle = UnsafeNativeMethods.OpenProcess(UnsafeNativeMethods.ProcessAccessFlags.PROCESS_VM_ALL, false, (uint) this.ProcessModel.ProcessID);
+                this.ProcessHandle = UnsafeNativeMethods.OpenProcess(UnsafeNativeMethods.ProcessAccessFlags.PROCESS_VM_READ, false, (uint) this.ProcessModel.ProcessID);
             }
             catch (Exception) {
                 this.ProcessHandle = processModel.Process.Handle;

--- a/Sharlayan/UnsafeNativeMethods.cs
+++ b/Sharlayan/UnsafeNativeMethods.cs
@@ -15,7 +15,20 @@ namespace Sharlayan {
 
     internal static class UnsafeNativeMethods {
         public enum ProcessAccessFlags {
-            PROCESS_VM_ALL = 0x001F0FFF
+            PROCESS_VM_ALL = 0x001F0FFF,
+            PROCESS_CREATE_PROCESS = 0x0080,
+            PROCESS_CREATE_THREAD = 0x0002,
+            PROCESS_DUP_HANDLE = 0x0040,
+            PROCESS_QUERY_INFORMATION = 0x0400,
+            PROCESS_QUERY_LIMITED_INFORMATION = 0x1000,
+            PROCESS_SET_INFORMATION = 0x0200,
+            PROCESS_SET_QUOTA = 0x0100,
+            PROCESS_SUSPEND_RESUME = 0x0800,
+            PROCESS_TERMINATE = 0x0001,
+            PROCESS_VM_OPERATION = 0x0008,
+            PROCESS_VM_READ = 0x0010,
+            PROCESS_VM_WRITE = 0x0020,
+            SYNCHRONIZE = 0x00100000,
         }
 
         [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]


### PR DESCRIPTION
Fixed ProcessAccessFlags to PROCESS_VM_READ for prevent Win32Exception.