### PR TITLE
Get entity of current player if it is null

### DIFF
--- a/Sharlayan/Reader.PlayerInfo.cs
+++ b/Sharlayan/Reader.PlayerInfo.cs
@@ -68,7 +68,11 @@ namespace Sharlayan {
                         }
                     }
                 }
-
+                
+                if (this._pcWorkerDelegate.CurrentUser == null) {
+                    this.GetActors();
+                }
+                
                 result.Entity = this._pcWorkerDelegate.CurrentUser;
             }
             catch (Exception ex) {


### PR DESCRIPTION
Now, if developer who want to fetch data from current player entity, they may get a null entity from `Reader.GetCurrentPlayer()`.
The reason is that sharlayan only update `_pcWorkerDelegate.CurrentUser`  in `Reader.GetActors()`.

https://github.com/FFXIVAPP/sharlayan/blob/91f1260f319493d5c40d7e738bcfab419a679d47/Sharlayan/Reader.Actor.cs#L150

This PR add the feature that get all actors once if the current user entity is not exist.