### PR TITLE
chore: bump dependencies (Dependabot #94-#100) + IsTeleporting + CI/CD fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
 
     steps:
       - name: Checkout (with submodules)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: recursive
 
       - name: Install .NET 10 SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,13 +28,13 @@ jobs:
       # is fully initialised; fetch-depth: 0 keeps full history for any version
       # scripts that inspect git tags.
       - name: Checkout (with submodules)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: recursive
 
       - name: Install .NET 10 SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
 
@@ -106,7 +106,7 @@ jobs:
             -p:GeneratePackageOnBuild=false
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sharlayan-${{ steps.version.outputs.full }}
           path: published/

--- a/Sharlayan/Models/ReadResults/GameStateResult.cs
+++ b/Sharlayan/Models/ReadResults/GameStateResult.cs
@@ -22,9 +22,17 @@ namespace Sharlayan.Models.ReadResults {
         /// <summary>GameMain.TerritoryLoadState raw byte: 1 = loading, 2 = loaded, 3 = unloading.</summary>
         public byte TerritoryLoadState { get; internal set; }
 
-        // --- Cutscene ------------------------------------------------------------------
+        // --- Cutscene & teleport -------------------------------------------------------
         /// <summary>True while a cutscene is playing (Conditions.WatchingCutscene / 78).</summary>
         public bool WatchingCutscene { get; internal set; }
+
+        /// <summary>
+        /// True while the player is travelling between zones or entering/exiting an instance
+        /// (Conditions.BetweenAreas or BetweenAreas51). Distinct from WatchingCutscene — a
+        /// genuine cutscene has WatchingCutscene=true and IsTeleporting=false. ActorItem.InCutscene
+        /// (from RenderFlags) fires for both; use IsTeleporting to tell them apart.
+        /// </summary>
+        public bool IsTeleporting { get; internal set; }
 
         // --- Duty Finder & instances ---------------------------------------------------
         /// <summary>Raw ContentsFinderQueueInfo.QueueState byte (0=None, 1=Pending, 2=Queued, 3=Ready (popped), 4=Accepted, 5=InContent).</summary>

--- a/Sharlayan/Reader.GameState.cs
+++ b/Sharlayan/Reader.GameState.cs
@@ -32,6 +32,8 @@ namespace Sharlayan {
         private static readonly int ConditionsOccupiedInCutSceneEventOffset = FieldOffsetReader.OffsetOf<FCSGame.Conditions>(nameof(FCSGame.Conditions.OccupiedInCutSceneEvent));
         private static readonly int ConditionsWatchingCutsceneOffset = FieldOffsetReader.OffsetOf<FCSGame.Conditions>(nameof(FCSGame.Conditions.WatchingCutscene));
         private static readonly int ConditionsWatchingCutscene78Offset = FieldOffsetReader.OffsetOf<FCSGame.Conditions>(nameof(FCSGame.Conditions.WatchingCutscene78));
+        private static readonly int ConditionsBetweenAreasOffset = FieldOffsetReader.OffsetOf<FCSGame.Conditions>(nameof(FCSGame.Conditions.BetweenAreas));
+        private static readonly int ConditionsBetweenAreas51Offset = FieldOffsetReader.OffsetOf<FCSGame.Conditions>(nameof(FCSGame.Conditions.BetweenAreas51));
         private static readonly int ContentsFinderQueueStateOffset =
             FieldOffsetReader.OffsetOf<FCSGameUI.ContentsFinder>(nameof(FCSGameUI.ContentsFinder.QueueInfo)) +
             FieldOffsetReader.OffsetOf<FCSGameUI.ContentsFinderQueueInfo>(nameof(FCSGameUI.ContentsFinderQueueInfo.QueueState));
@@ -80,18 +82,24 @@ namespace Sharlayan {
             // IsReadyToRead: territory is loaded AND the scanner resolved the actor pointer array.
             result.IsReadyToRead = result.TerritoryLoadState == 2 && locations.ContainsKey(Signatures.CHARMAP_KEY);
 
-            // --- Conditions: FCS exposes three cutscene-related flags on the same struct.
+            // --- Conditions: cutscene and teleport flags live on the same struct. ---
             //   OccupiedInCutSceneEvent — explicit cutscene-event condition (quest/story).
-            //   WatchingCutscene        — generic "watching a cutscene" flag.
-            //   WatchingCutscene78      — secondary flag set during instance cutscenes.
-            // OR all three so short unskippable cutscenes (which only trip one) still register.
+            //   WatchingCutscene / 78   — generic cutscene flag; 78 fires for instance cutscenes.
+            //   BetweenAreas / 51       — set during zone transitions and instance entry/exit.
+            //
+            // IsTeleporting uses BetweenAreas|51 only. InCutscene on ActorItem (RenderFlags bit)
+            // fires for both cutscenes AND zone transitions; using IsTeleporting lets callers
+            // distinguish the two: a real cutscene has WatchingCutscene=true, IsTeleporting=false.
             if (locations.ContainsKey(Signatures.CONDITIONS_KEY)) {
                 IntPtr conditions = locations[Signatures.CONDITIONS_KEY];
                 try {
-                    byte occCutscene = this._memoryHandler.GetByte(conditions, ConditionsOccupiedInCutSceneEventOffset);
-                    byte watching58  = this._memoryHandler.GetByte(conditions, ConditionsWatchingCutsceneOffset);
-                    byte watching78  = this._memoryHandler.GetByte(conditions, ConditionsWatchingCutscene78Offset);
+                    byte occCutscene  = this._memoryHandler.GetByte(conditions, ConditionsOccupiedInCutSceneEventOffset);
+                    byte watching58   = this._memoryHandler.GetByte(conditions, ConditionsWatchingCutsceneOffset);
+                    byte watching78   = this._memoryHandler.GetByte(conditions, ConditionsWatchingCutscene78Offset);
+                    byte betweenAreas = this._memoryHandler.GetByte(conditions, ConditionsBetweenAreasOffset);
+                    byte between51    = this._memoryHandler.GetByte(conditions, ConditionsBetweenAreas51Offset);
                     result.WatchingCutscene = occCutscene != 0 || watching58 != 0 || watching78 != 0;
+                    result.IsTeleporting    = betweenAreas != 0 || between51 != 0;
                 }
                 catch { /* ignore */ }
             }

--- a/Sharlayan/Sharlayan.csproj
+++ b/Sharlayan/Sharlayan.csproj
@@ -53,10 +53,10 @@
 	<ItemGroup>
 		<PackageReference Include="Lumina" Version="7.3.0" />
 		<PackageReference Include="Lumina.Excel" Version="7.4.3" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-		<PackageReference Include="NLog" Version="5.1.0" />
-		<PackageReference Include="NLog.Schema" Version="5.1.0" />
-		<PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.34" PrivateAssets="all" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+		<PackageReference Include="NLog" Version="6.1.2" />
+		<PackageReference Include="NLog.Schema" Version="6.1.2" />
+		<PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.44.2" PrivateAssets="all" />
 	</ItemGroup>
 
 	<!-- Test-only access for internal members (e.g. MapLanguage in Reader.Lumina.cs).

--- a/Sharlayan/version.props
+++ b/Sharlayan/version.props
@@ -5,7 +5,7 @@
          Patch: incremented by Claude/AI on each substantive code change to Sharlayan. -->
     <VersionMajor>9</VersionMajor>
     <VersionMinor>0</VersionMinor>
-    <VersionPatch>5</VersionPatch>
+    <VersionPatch>6</VersionPatch>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Derived version strings — do not edit these directly. -->

--- a/Sharlayan/version.props
+++ b/Sharlayan/version.props
@@ -5,7 +5,7 @@
          Patch: incremented by Claude/AI on each substantive code change to Sharlayan. -->
     <VersionMajor>9</VersionMajor>
     <VersionMinor>0</VersionMinor>
-    <VersionPatch>6</VersionPatch>
+    <VersionPatch>7</VersionPatch>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Derived version strings — do not edit these directly. -->


### PR DESCRIPTION
## Summary

Post-merge housekeeping on `sharlayan-9-rebuild` following the main rebuild PR. Covers the Dependabot recommendations plus a few CI/CD and feature additions made during the rebuild workflow validation.

## Dependency changes

| Package | From | To |
|---|---|---|
| Newtonsoft.Json | 13.0.2 | 13.0.4 |
| NLog | 5.1.0 | 6.1.2 |
| NLog.Schema | 5.1.0 | 6.1.2 |
| ILRepack.Lib.MSBuild.Task | 2.0.34 | 2.0.44.2 |
| actions/checkout | v4 | v6 |
| actions/setup-dotnet | v4 | v5 |
| actions/upload-artifact | v4 | v7 |

Dependabot PRs #94–#100 closed in favour of this batch commit.

## Other changes

- `GameStateResult.IsTeleporting` — reads `Conditions.BetweenAreas` / `BetweenAreas51` to distinguish zone transitions from actual cutscenes (ActorItem.InCutscene fires for both)
- CI/CD: NuGet publishing switched to OIDC trusted publishing via `NuGet/login@v1`; fixed Release build HintPaths, `published/` folder, and symbols format (`.snupkg`)
- `NLog.xsd` updated to NLog 6.1.2 schema

## Test plan
- [x] 134 unit tests pass
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)