### PR TITLE
perf: share Lumina GameData + cache sheets to cut memory and per-frame overhead

### DIFF
--- a/Sharlayan/Reader.GameState.cs
+++ b/Sharlayan/Reader.GameState.cs
@@ -15,13 +15,13 @@
 
 namespace Sharlayan {
     using System;
-    using System.IO;
 
     using FCSGame = FFXIVClientStructs.FFXIV.Client.Game;
     using FCSGameUI = FFXIVClientStructs.FFXIV.Client.Game.UI;
 
     using Sharlayan.Models.ReadResults;
     using Sharlayan.Resources.Mappers;
+    using Sharlayan.Resources.Providers;
 
     public partial class Reader {
         // Every inner offset used by GetGameState is derived at class init via
@@ -45,12 +45,14 @@ namespace Sharlayan {
         private const int StdVectorFirstOffset = 0;
         private const int StdVectorLastOffset = 8;
 
-        // Lumina GameData is lazily constructed on first GetGameState call and cached
-        // for the Reader's lifetime. `_luminaAttempted` prevents re-probing the sqpack
-        // path every frame when GameInstallPath is unset or the sqpack directory can't
-        // be located.
-        private Lumina.GameData _luminaGameData;
-        private bool _luminaAttempted;
+        // Sheet refs resolved once via LuminaGameDataCache and cached for the Reader's
+        // lifetime. Per-frame calls to GetSheet<T>() would still hit Lumina's internal
+        // dictionary + generic dispatch; field reads are effectively free. `_sheetsAttempted`
+        // prevents re-probing sqpack every frame when GameInstallPath is unset or the
+        // Lumina open failed.
+        private Lumina.Excel.ExcelSheet<Lumina.Excel.Sheets.Weather> _weatherSheetEn;
+        private Lumina.Excel.ExcelSheet<Lumina.Excel.Sheets.BGM> _bgmSheetEn;
+        private bool _sheetsAttempted;
 
         public bool CanGetGameState() {
             // At minimum we need GameMain to read territory-load state. The other keys are
@@ -154,21 +156,13 @@ namespace Sharlayan {
             }
 
             // --- Lumina name resolution (best-effort; silently skipped if sqpack not found) ---
+            this.EnsureLuminaSheets();
             try {
-                Lumina.GameData lumina = this.GetLumina();
-                if (lumina != null) {
-                    if (result.CurrentWeatherId != 0) {
-                        var weatherSheet = lumina.Excel.GetSheet<Lumina.Excel.Sheets.Weather>();
-                        if (weatherSheet.HasRow(result.CurrentWeatherId)) {
-                            result.CurrentWeatherName = weatherSheet.GetRow(result.CurrentWeatherId).Name.ExtractText();
-                        }
-                    }
-                    if (result.CurrentBgmId != 0) {
-                        var bgmSheet = lumina.Excel.GetSheet<Lumina.Excel.Sheets.BGM>();
-                        if (bgmSheet.HasRow(result.CurrentBgmId)) {
-                            result.CurrentBgmFile = bgmSheet.GetRow(result.CurrentBgmId).File.ExtractText();
-                        }
-                    }
+                if (this._weatherSheetEn != null && result.CurrentWeatherId != 0 && this._weatherSheetEn.HasRow(result.CurrentWeatherId)) {
+                    result.CurrentWeatherName = this._weatherSheetEn.GetRow(result.CurrentWeatherId).Name.ExtractText();
+                }
+                if (this._bgmSheetEn != null && result.CurrentBgmId != 0 && this._bgmSheetEn.HasRow(result.CurrentBgmId)) {
+                    result.CurrentBgmFile = this._bgmSheetEn.GetRow(result.CurrentBgmId).File.ExtractText();
                 }
             }
             catch { /* Lumina failures shouldn't break the numeric result */ }
@@ -176,36 +170,26 @@ namespace Sharlayan {
             return result;
         }
 
-        private Lumina.GameData GetLumina() {
-            if (this._luminaAttempted) {
-                return this._luminaGameData;
+        // Resolve the EN Weather and BGM sheets once, lazily. Per-frame GetGameState reads
+        // them as fields — no dictionary lookup, no generic dispatch.
+        private void EnsureLuminaSheets() {
+            if (this._sheetsAttempted) {
+                return;
             }
-            this._luminaAttempted = true;
+            this._sheetsAttempted = true;
+            Lumina.GameData lumina = LuminaGameDataCache.GetOrNull(this._memoryHandler.Configuration);
+            if (lumina == null) {
+                return;
+            }
             try {
-                string sqpack = ResolveSqpackPath(this._memoryHandler.Configuration);
-                if (sqpack != null) {
-                    this._luminaGameData = new Lumina.GameData(sqpack);
-                }
+                this._weatherSheetEn = lumina.Excel.GetSheet<Lumina.Excel.Sheets.Weather>();
+                this._bgmSheetEn = lumina.Excel.GetSheet<Lumina.Excel.Sheets.BGM>();
             }
-            catch { /* leave cache null; subsequent calls return null without retrying */ }
-            return this._luminaGameData;
+            catch { /* leave fields null; subsequent calls skip the lookup */ }
         }
 
-        // Mirrors LuminaXivDatabaseProvider.ResolveSqpackPath but returns null on any failure
-        // instead of throwing — GetGameState must work even without xivdatabase access.
-        private static string ResolveSqpackPath(SharlayanConfiguration configuration) {
-            if (!string.IsNullOrWhiteSpace(configuration?.GameInstallPath)) {
-                string gameSqpack = Path.Combine(configuration.GameInstallPath, "game", "sqpack");
-                if (Directory.Exists(gameSqpack)) return gameSqpack;
-                string rootSqpack = Path.Combine(configuration.GameInstallPath, "sqpack");
-                if (Directory.Exists(rootSqpack)) return rootSqpack;
-            }
-            string exePath = configuration?.ProcessModel?.Process?.MainModule?.FileName;
-            if (string.IsNullOrWhiteSpace(exePath)) return null;
-            string gameDir = Path.GetDirectoryName(exePath);
-            if (string.IsNullOrWhiteSpace(gameDir)) return null;
-            string guess = Path.Combine(gameDir, "sqpack");
-            return Directory.Exists(guess) ? guess : null;
-        }
+        // Thin accessor retained so Reader.Lumina can resolve language-specific sheets
+        // (zone / weather / exp-table helpers) via the same shared cache.
+        private Lumina.GameData GetLumina() => LuminaGameDataCache.GetOrNull(this._memoryHandler.Configuration);
     }
 }

--- a/Sharlayan/Resources/Providers/LuminaGameDataCache.cs
+++ b/Sharlayan/Resources/Providers/LuminaGameDataCache.cs
@@ -1,0 +1,114 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="LuminaGameDataCache.cs" company="SyndicatedLife">
+//   Copyright© 2007 - 2022 Ryan Wilson <syndicated.life@gmail.com> (https://syndicated.life/)
+//   Licensed under the MIT license. See LICENSE.md in the solution root for full license information.
+// </copyright>
+// <summary>
+//   Process-wide cache of Lumina <see cref="Lumina.GameData"/> instances keyed on sqpack path.
+//   Opening a GameData loads the sqpack indexes (tens of MB) — every consumer that wants
+//   Excel data (Reader.GameState's per-frame weather/BGM lookups, Reader.Lumina's name
+//   helpers, LuminaXivDatabaseProvider's bulk actions/statuses/zones load) must share a
+//   single instance per sqpack directory.
+//
+//   The cached GameData is constructed with tuned <see cref="Lumina.LuminaOptions"/>:
+//     - CacheFileResources = false   : Sharlayan only reads Excel sheets; disable Lumina's
+//                                       raw-file blob cache which otherwise grows unbounded.
+//     - PanicOnSheetChecksumMismatch = false : tolerate patch-day checksum drift rather than
+//                                       throwing and killing a whole call chain.
+//     - LoadMultithreaded = true     : parallelise the initial sqpack index load.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Sharlayan.Resources.Providers {
+    using System;
+    using System.Collections.Concurrent;
+    using System.IO;
+
+    using Lumina;
+
+    internal static class LuminaGameDataCache {
+        private static readonly ConcurrentDictionary<string, GameData> _cache = new ConcurrentDictionary<string, GameData>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Returns the cached <see cref="GameData"/> for the configuration's sqpack path,
+        /// or <c>null</c> if the path can't be resolved or GameData construction fails.
+        /// Used by per-frame / best-effort callers that must degrade gracefully.
+        /// </summary>
+        public static GameData GetOrNull(SharlayanConfiguration configuration) {
+            string sqpack = TryResolveSqpackPath(configuration);
+            if (sqpack == null) {
+                return null;
+            }
+            try {
+                return _cache.GetOrAdd(sqpack, CreateGameData);
+            }
+            catch {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Returns the cached <see cref="GameData"/> for the configuration's sqpack path,
+        /// throwing if the path can't be resolved. Used by the xivdatabase provider's bulk
+        /// loaders where a missing sqpack is a genuine configuration error.
+        /// </summary>
+        public static GameData Get(SharlayanConfiguration configuration) {
+            string sqpack = ResolveSqpackPathStrict(configuration);
+            return _cache.GetOrAdd(sqpack, CreateGameData);
+        }
+
+        private static GameData CreateGameData(string sqpack) {
+            return new GameData(sqpack, new LuminaOptions {
+                CacheFileResources = false,
+                PanicOnSheetChecksumMismatch = false,
+                LoadMultithreaded = true,
+            });
+        }
+
+        // Lenient resolver — returns null on any missing input. Mirrors what
+        // Reader.GameState used to do inline before this cache was introduced.
+        private static string TryResolveSqpackPath(SharlayanConfiguration configuration) {
+            if (!string.IsNullOrWhiteSpace(configuration?.GameInstallPath)) {
+                string gameSqpack = Path.Combine(configuration.GameInstallPath, "game", "sqpack");
+                if (Directory.Exists(gameSqpack)) return gameSqpack;
+                string rootSqpack = Path.Combine(configuration.GameInstallPath, "sqpack");
+                if (Directory.Exists(rootSqpack)) return rootSqpack;
+            }
+            string exePath = configuration?.ProcessModel?.Process?.MainModule?.FileName;
+            if (string.IsNullOrWhiteSpace(exePath)) return null;
+            string gameDir = Path.GetDirectoryName(exePath);
+            if (string.IsNullOrWhiteSpace(gameDir)) return null;
+            string guess = Path.Combine(gameDir, "sqpack");
+            return Directory.Exists(guess) ? guess : null;
+        }
+
+        // Strict resolver — throws on missing input. Mirrors what
+        // LuminaXivDatabaseProvider used to do inline before this cache was introduced.
+        private static string ResolveSqpackPathStrict(SharlayanConfiguration configuration) {
+            if (!string.IsNullOrWhiteSpace(configuration?.GameInstallPath)) {
+                string explicitSqpack = Path.Combine(configuration.GameInstallPath, "game", "sqpack");
+                if (Directory.Exists(explicitSqpack)) {
+                    return explicitSqpack;
+                }
+                explicitSqpack = Path.Combine(configuration.GameInstallPath, "sqpack");
+                if (Directory.Exists(explicitSqpack)) {
+                    return explicitSqpack;
+                }
+                throw new DirectoryNotFoundException($"sqpack directory not found under configured GameInstallPath '{configuration.GameInstallPath}'.");
+            }
+
+            string exePath = configuration?.ProcessModel?.Process?.MainModule?.FileName
+                             ?? throw new InvalidOperationException("Cannot locate game sqpack: no GameInstallPath set and no running ProcessModel available.");
+
+            string gameDir = Path.GetDirectoryName(exePath)
+                             ?? throw new InvalidOperationException($"Cannot derive game directory from exe path '{exePath}'.");
+
+            string sqpack = Path.Combine(gameDir, "sqpack");
+            if (!Directory.Exists(sqpack)) {
+                throw new DirectoryNotFoundException($"sqpack directory not found at '{sqpack}'.");
+            }
+
+            return sqpack;
+        }
+    }
+}

--- a/Sharlayan/Resources/Providers/LuminaXivDatabaseProvider.cs
+++ b/Sharlayan/Resources/Providers/LuminaXivDatabaseProvider.cs
@@ -15,7 +15,6 @@
 namespace Sharlayan.Resources.Providers {
     using System;
     using System.Collections.Concurrent;
-    using System.IO;
     using System.Threading.Tasks;
 
     using Lumina;
@@ -43,7 +42,7 @@ namespace Sharlayan.Resources.Providers {
 
         public Task GetActionsAsync(ConcurrentDictionary<uint, ActionItem> actions, SharlayanConfiguration configuration) {
             return Task.Run(() => {
-                GameData gameData = OpenGameData(configuration);
+                GameData gameData = LuminaGameDataCache.Get(configuration);
                 ExcelSheet<NativeAction> en = gameData.Excel.GetSheet<NativeAction>(Language.English);
                 ExcelSheet<NativeAction> jp = gameData.Excel.GetSheet<NativeAction>(Language.Japanese);
                 ExcelSheet<NativeAction> de = gameData.Excel.GetSheet<NativeAction>(Language.German);
@@ -84,7 +83,7 @@ namespace Sharlayan.Resources.Providers {
 
         public Task GetStatusEffectsAsync(ConcurrentDictionary<uint, StatusItem> statusEffects, SharlayanConfiguration configuration) {
             return Task.Run(() => {
-                GameData gameData = OpenGameData(configuration);
+                GameData gameData = LuminaGameDataCache.Get(configuration);
                 ExcelSheet<NativeStatus> en = gameData.Excel.GetSheet<NativeStatus>(Language.English);
                 ExcelSheet<NativeStatus> jp = gameData.Excel.GetSheet<NativeStatus>(Language.Japanese);
                 ExcelSheet<NativeStatus> de = gameData.Excel.GetSheet<NativeStatus>(Language.German);
@@ -107,7 +106,7 @@ namespace Sharlayan.Resources.Providers {
 
         public Task GetZonesAsync(ConcurrentDictionary<uint, MapItem> zones, SharlayanConfiguration configuration) {
             return Task.Run(() => {
-                GameData gameData = OpenGameData(configuration);
+                GameData gameData = LuminaGameDataCache.Get(configuration);
                 ExcelSheet<NativeTerritoryType> territories = gameData.Excel.GetSheet<NativeTerritoryType>();
 
                 ExcelSheet<PlaceName> placeNameEn = gameData.Excel.GetSheet<PlaceName>(Language.English);
@@ -131,44 +130,6 @@ namespace Sharlayan.Resources.Providers {
                     zones.AddOrUpdate(id, item, (_, _) => item);
                 }
             });
-        }
-
-        private static GameData OpenGameData(SharlayanConfiguration configuration) {
-            string sqpackPath = ResolveSqpackPath(configuration);
-            return new GameData(sqpackPath);
-        }
-
-        /// <summary>
-        /// Resolves the sqpack directory path either from the explicit
-        /// <see cref="SharlayanConfiguration.GameInstallPath"/> override, or (falling back)
-        /// from the running game's MainModule file path (ffxiv_dx11.exe sits next to sqpack/).
-        /// </summary>
-        private static string ResolveSqpackPath(SharlayanConfiguration configuration) {
-            if (!string.IsNullOrWhiteSpace(configuration.GameInstallPath)) {
-                string explicitSqpack = Path.Combine(configuration.GameInstallPath, "game", "sqpack");
-                if (Directory.Exists(explicitSqpack)) {
-                    return explicitSqpack;
-                }
-                // Also accept if GameInstallPath is already the game\ folder
-                explicitSqpack = Path.Combine(configuration.GameInstallPath, "sqpack");
-                if (Directory.Exists(explicitSqpack)) {
-                    return explicitSqpack;
-                }
-                throw new DirectoryNotFoundException($"sqpack directory not found under configured GameInstallPath '{configuration.GameInstallPath}'.");
-            }
-
-            string exePath = configuration.ProcessModel?.Process?.MainModule?.FileName
-                             ?? throw new InvalidOperationException("Cannot locate game sqpack: no GameInstallPath set and no running ProcessModel available.");
-
-            string gameDir = Path.GetDirectoryName(exePath)
-                             ?? throw new InvalidOperationException($"Cannot derive game directory from exe path '{exePath}'.");
-
-            string sqpack = Path.Combine(gameDir, "sqpack");
-            if (!Directory.Exists(sqpack)) {
-                throw new DirectoryNotFoundException($"sqpack directory not found at '{sqpack}'.");
-            }
-
-            return sqpack;
         }
 
         private static Localization BuildLocalization(string english, string japanese, string german, string french) {

--- a/Sharlayan/Sharlayan.xml
+++ b/Sharlayan/Sharlayan.xml
@@ -164,11 +164,18 @@
                final PointerPath = [rewindBack, 0 (deref Framework ptr), 0x2B68 (deref UIModule field), 0x19E0 (trailing add)]
              </summary>
         </member>
-        <member name="M:Sharlayan.Resources.Providers.LuminaXivDatabaseProvider.ResolveSqpackPath(Sharlayan.SharlayanConfiguration)">
+        <member name="M:Sharlayan.Resources.Providers.LuminaGameDataCache.GetOrNull(Sharlayan.SharlayanConfiguration)">
             <summary>
-            Resolves the sqpack directory path either from the explicit
-            <see cref="P:Sharlayan.SharlayanConfiguration.GameInstallPath"/> override, or (falling back)
-            from the running game's MainModule file path (ffxiv_dx11.exe sits next to sqpack/).
+            Returns the cached <see cref="T:Lumina.GameData"/> for the configuration's sqpack path,
+            or <c>null</c> if the path can't be resolved or GameData construction fails.
+            Used by per-frame / best-effort callers that must degrade gracefully.
+            </summary>
+        </member>
+        <member name="M:Sharlayan.Resources.Providers.LuminaGameDataCache.Get(Sharlayan.SharlayanConfiguration)">
+            <summary>
+            Returns the cached <see cref="T:Lumina.GameData"/> for the configuration's sqpack path,
+            throwing if the path can't be resolved. Used by the xivdatabase provider's bulk
+            loaders where a missing sqpack is a genuine configuration error.
             </summary>
         </member>
     </members>

--- a/Sharlayan/version.props
+++ b/Sharlayan/version.props
@@ -5,7 +5,7 @@
          Patch: incremented by Claude/AI on each substantive code change to Sharlayan. -->
     <VersionMajor>9</VersionMajor>
     <VersionMinor>0</VersionMinor>
-    <VersionPatch>8</VersionPatch>
+    <VersionPatch>9</VersionPatch>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Derived version strings — do not edit these directly. -->


### PR DESCRIPTION
## Summary
- Introduces `LuminaGameDataCache` — a process-wide `ConcurrentDictionary<string, GameData>` keyed on sqpack path — so all consumers (Reader.GameState per-frame weather/BGM, Reader.Lumina name helpers, LuminaXivDatabaseProvider bulk actions/statuses/zones) share one Lumina instance per sqpack directory instead of each minting their own.
- Tuned `LuminaOptions` on construction: `CacheFileResources = false` (Sharlayan only reads Excel sheets; disables the unbounded raw-file blob cache), `PanicOnSheetChecksumMismatch = false` (tolerate patch-day drift), `LoadMultithreaded = true` (parallel sqpack index load).
- `Reader.GameState` now resolves the EN Weather and BGM sheets once into fields, so per-frame `GetGameState()` skips the dictionary lookup and generic dispatch that `GetSheet<T>()` incurs.
- No public API changes — downstream consumers (Chromatics) pick up the smaller footprint as a drop-in.

## Test plan
- [x] `dotnet test` — 134/134 passing
- [x] Debug build + deploy to Chromatics Build Dependencies
- [x] Live verify: Chromatics session shows the usual per-frame data with no regressions in weather/BGM name resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)