### PR TITLE
feat: per-scene BGM array + preset fade lookup + audible/loading signals

### DIFF
--- a/DEPENDENCY.md
+++ b/DEPENDENCY.md
@@ -26,7 +26,8 @@ Each of these has a `public static partial Instance()` method decorated with `[S
 | `FFXIV/Client/Game/Conditions.cs` | `Conditions` | `CONDITIONS` | bool array; bits 35 / 58 / 78 for cutscene, 34 for BoundByDuty |
 | `FFXIV/Client/Game/UI/ContentsFinder.cs` | `ContentsFinder` | `CONTENTSFINDER` | `QueueInfo.QueueState` @ +0x75 |
 | `FFXIV/Client/Game/WeatherManager.cs` | `WeatherManager` | `WEATHER` | `WeatherId` @ +0x64 |
-| `FFXIV/Client/Game/BGMSystem.cs` | `BGMSystem` | `BGMSYSTEM` | `Scenes` StdVector @ +0xC0 walked for highest-priority PlayingBgmId; `isPointer=true` |
+| `FFXIV/Client/Game/BGMSystem.cs` | `BGMSystem` | `BGMSYSTEM` | `Scenes` StdVector @ +0xC0 walked: each scene exposes `PlayingBgmId` (+0x0E), `BgmId` (+0x0C), `PreviousBgmId` (+0x10), `PlayState` (+0x50), `EnableCustomFade` (+0x30), `FadeOutTime` (+0x38), `FadeInTime` (+0x3C) into `BgmScenes[]`. Per-scene Lumina preset fades (`Preset*` floats in seconds) sourced from `BGMFade.SceneIn` → `BGMFadeType` (FadeOutTime / FadeInTime / FadeInStartTime / ResumeFadeInTime). Highest-priority non-silence `PlayingBgmId` also flat-mapped to `CurrentBgmId/SceneId/TargetId`. `isPointer=true` |
+| `FFXIV/Client/Sound/SoundManager.cs` | `SoundManager` | `SOUNDMANAGER` | `ActiveSoundDataListHead` @ +0x228 walked via `ISoundData.Next` (+0x18) reading `SoundData.IsLoadingSoundResource` (+0xB8) → `AnySoundLoading`. First 8 floats of private `_FFTBlue1` (+0x1358, post-master-volume music-bus FFT) summed → `IsBgmAudible`. `isPointer=true` |
 | `FFXIV/Client/System/Framework/Framework.cs` | `Framework` | `CHATLOG`, `HOTBAR` | Multi-hop base for UIModule chain (see below); `isPointer=true` |
 | `FFXIV/Component/GUI/AtkStage.cs` | `AtkStage` | `RECAST` | Multi-hop base for NumberArray chain (see below); `isPointer=true` |
 

--- a/Sharlayan.Harness/Program.cs
+++ b/Sharlayan.Harness/Program.cs
@@ -7,7 +7,12 @@
 //   Validation harness for Sharlayan v9. Run while FFXIV is running; produces a
 //   structured report validating the FFXIVClientStructsDirect provider against
 //   live game state and Lumina xivdatabase content.
-//   Intended to be pasted back to the session that's developing the refactor.
+//
+//   On first pass the full report ([1]..[4]) is written to the console and to
+//   the --out= file. The harness then enters a live-refresh loop that redraws
+//   only the [3c]/[3c.2] eye-check + GameState blocks in place, so the user
+//   can watch values change in-game without the console spamming. Press Ctrl+C
+//   to exit.
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -29,15 +34,21 @@ using FFXIVClientStructs.FFXIV.Component.Log;
 using Sharlayan;
 using Sharlayan.Models;
 using Sharlayan.Resources;
+using Sharlayan.Resources.Mappers;
+
+using FCSGame = FFXIVClientStructs.FFXIV.Client.Game;
 
 namespace Sharlayan.Harness;
 
 internal static class Program {
     private const string ProcessName = "ffxiv_dx11";
+    private const int DefaultLiveIntervalMs = 500;
 
     private static async Task<int> Main(string[] args) {
         StringBuilder report = new();
         string? outFilePath = args.FirstOrDefault(a => a.StartsWith("--out="))?.Substring("--out=".Length);
+        bool runOnce = args.Any(a => a == "--once");
+        int liveIntervalMs = ParseIntArg(args, "--interval=", DefaultLiveIntervalMs);
 
         void Log(string line) {
             Console.WriteLine(line);
@@ -72,7 +83,8 @@ internal static class Program {
         }
         Log(string.Empty);
 
-        // [2] FFXIVClientStructs struct sizes (runtime vs declared) -----------
+        // [2] FFXIVClientStructs struct sizes — commented out; re-enable for FCS-bump diagnostics.
+        /*
         Log("[2] FFXIVCLIENTSTRUCTS STRUCT SIZES (runtime Marshal.SizeOf)");
         DumpSize<Character>(Log, 0x2370);
         DumpSize<CharacterData>(Log, 0x50);
@@ -94,6 +106,7 @@ internal static class Program {
         DumpSize<LogModule>(Log, 0x80);
         DumpSize<Vector3>(Log, 0x0C);
         Log(string.Empty);
+        */
 
         // [3] FFXIVClientStructsDirect scanner + reader ----------------------
         SharlayanConfiguration directConfig = new() {
@@ -114,15 +127,17 @@ internal static class Program {
 
             int directCount = directHandler.Scanner.Locations.Count;
             Log($"  {directCount} location(s) resolved");
+            // Address listing — commented out; re-enable to verify all scanner keys resolved.
+            /*
             foreach (string key in directHandler.Scanner.Locations.Keys.OrderBy(k => k)) {
                 IntPtr addr = directHandler.Scanner.Locations[key];
                 Log($"    ✓ {key,-20} 0x{addr.ToInt64():X12}");
             }
+            */
 
-            // [3b] End-to-end Reader check. Addresses in [3] resolving correctly is
-            // necessary but not sufficient — the Reader also needs the StructuresContainer
-            // offsets to align with the live game layout. This block reads the same fields
-            // Chromatics consumes and logs them for eye-verification against the in-game UI.
+            // [3b] End-to-end Reader check — commented out; re-enable to validate
+            // CurrentPlayer / Actors / Party reads against the in-game UI.
+            /*
             Log(string.Empty);
             Log("  [3b] READER OUTPUT");
             try {
@@ -161,172 +176,14 @@ internal static class Program {
             catch (Exception ex) {
                 Log($"    ✗ Party: {ex.GetType().Name}: {ex.Message}");
             }
+            */
 
-            // [3c] Eye-check values — read fields from the local player and nearby actors
-            // so the developer can compare against the in-game UI. These need manual verification.
-            try {
-                var dp = directHandler.Reader.GetCurrentPlayer()?.Entity;
-                if (dp != null) {
-                    Log(string.Empty);
-                    Log("  [3c] EYE-CHECK VALUES");
-                    Log($"    LocalPlayer.TargetID   = 0x{dp.TargetID:X8}   (0 when not targeting)");
-                    Log($"    LocalPlayer.ClaimedByID= 0x{dp.ClaimedByID:X8}   (combat-tag owner; 0 when not in combat)");
-                    Log($"    LocalPlayer.NPCID1     = {dp.NPCID1}");
-                    Log($"    LocalPlayer.NPCID2     = {dp.NPCID2}   (NameId — 0 for players, row id for NPCs)");
-                    Log($"    LocalPlayer.Type       = {dp.Type}   (1=Pc, 2=BattleNpc, 3=EventNpc, 4=Treasure, ...)");
-                    Log($"    LocalPlayer.TargetFlags= {dp.TargetFlags}   (targetability; see ObjectTargetableFlags)");
-                    Log($"    LocalPlayer.Title      = {dp.Title}   (TitleId — compare against /title list)");
-                    Log($"    LocalPlayer.Icon       = {dp.Icon}   (nameplate icon id)");
-                    Log($"    LocalPlayer.HitBoxRadius={dp.HitBoxRadius}");
-                    Log($"    LocalPlayer.IsAgroed   = {dp.IsAgroed}   (CharacterData.Flags bit 1 = InCombat; True when engaged)");
-                    Log($"    LocalPlayer.InCombat   = {dp.InCombat}   (same byte, same bit — should match IsAgroed for local player)");
-                    Log($"    LocalPlayer.IsAggressive= {dp.IsAggressive}   (bit 0 = IsHostile)");
-                    Log($"    LocalPlayer.AgroFlags  = 0x{dp.AgroFlags:X2} CombatFlags=0x{dp.CombatFlags:X2}   (bit0=IsHostile bit1=InCombat)");
-                    Log($"    LocalPlayer.InCutscene = {dp.InCutscene}   (ActorItem.InCutscene — currently unmapped in direct, see raw RenderFlags below)");
+            // [3c] + [3c.2] — extracted so the live-refresh loop below can call the
+            // same renderer and keep its output pointing at fresh in-game values.
+            RenderEyeCheckAndGameState(directHandler, Log);
 
-                    try {
-                        if (directHandler.Scanner.Locations.TryGetValue(Sharlayan.Signatures.CHARMAP_KEY, out var charmap)) {
-                            long firstActorAddr = directHandler.GetInt64(charmap);
-                            if (firstActorAddr != 0) {
-                                IntPtr actor = new IntPtr(firstActorAddr);
-                                byte tgtStatus      = directHandler.GetByte(actor, 0x95);
-                                byte targetable     = directHandler.GetByte(actor, 0x9A);
-                                byte renderFlagsLo  = directHandler.GetByte(actor, 0x118);
-                                byte renderFlagsHi  = directHandler.GetByte(actor, 0x119);
-                                Log($"    LocalPlayer raw @ CHARMAP[0]: TargetStatus@0x95=0x{tgtStatus:X2} TargetableStatus@0x9A=0x{targetable:X2} RenderFlags@0x118=0x{renderFlagsLo:X2} RenderFlags@0x119=0x{renderFlagsHi:X2}");
-                                Log($"      (Model bit = 0x02 on 0x118; during a cutscene this typically drops. Watch which byte changes.)");
-                            }
-                        }
-                    }
-                    catch (Exception ex) {
-                        Log($"    ✗ Raw actor byte dump: {ex.GetType().Name}: {ex.Message}");
-                    }
-                }
-
-                var dActors2 = directHandler.Reader.GetActors();
-                var sample = dActors2.CurrentNPCs.Values.Take(3).ToList();
-                foreach (var mob in dActors2.CurrentMonsters.Values.Take(2)) sample.Add(mob);
-                if (sample.Count > 0) {
-                    Log($"    Sample actors ({sample.Count}):");
-                    foreach (var a in sample) {
-                        Log($"      - {a.Name,-24} Type={a.Type} ID=0x{a.ID:X8} HP={a.HPCurrent}/{a.HPMax} IsAgroed={a.IsAgroed} AgroFlags=0x{a.AgroFlags:X2}");
-                    }
-                }
-
-                try {
-                    var tr = directHandler.Reader.GetTargetInfo();
-                    var ti = tr?.TargetInfo;
-                    if (ti == null) {
-                        Log("    CurrentTarget: (TargetInfo null)");
-                    }
-                    else {
-                        void DumpTarget(string label, Sharlayan.Core.ActorItem? t) {
-                            if (t == null) { Log($"    {label}: (none)"); return; }
-                            Log($"    {label}: \"{t.Name}\" Type={t.Type} ID=0x{t.ID:X8} HP={t.HPCurrent}/{t.HPMax}");
-                            Log($"      IsAgroed={t.IsAgroed}  AgroFlags=0x{t.AgroFlags:X2}  CombatFlags=0x{t.CombatFlags:X2}  ClaimedByID=0x{t.ClaimedByID:X8}");
-                            Log($"      IsCasting={t.IsCasting1}  CastingID={t.CastingID}  CastingProgress={t.CastingProgress:F2}/{t.CastingTime:F2}s  CastTargetID=0x{t.CastingTargetID:X8}");
-                            Log($"      Pos=({t.X:F1},{t.Y:F1},{t.Z:F1})  TargetID=0x{t.TargetID:X8}  NPCID2={t.NPCID2}");
-                        }
-                        DumpTarget("CurrentTarget", ti.CurrentTarget);
-                        if (ti.FocusTarget != null) DumpTarget("FocusTarget",   ti.FocusTarget);
-                        if (ti.MouseOverTarget != null) DumpTarget("MouseOverTarget", ti.MouseOverTarget);
-                        if (ti.CurrentTarget == null && ti.FocusTarget == null && ti.MouseOverTarget == null) {
-                            Log($"    CurrentTargetID = 0x{ti.CurrentTargetID:X8}  (no resolved target — target offscreen or between actor frames)");
-                        }
-                        if (ti.EnmityItems.Count > 0) {
-                            Log($"    EnmityItems ({ti.EnmityItems.Count}):");
-                            foreach (var e in ti.EnmityItems) {
-                                Log($"      ID=0x{e.ID:X8}  Enmity={e.Enmity,8}  Name=\"{e.Name}\"");
-                            }
-                        }
-                        else {
-                            Log($"    EnmityItems: (none — target a mob while in combat to populate)");
-                        }
-                    }
-                }
-                catch (Exception ex) {
-                    Log($"    ✗ Target: {ex.GetType().Name}: {ex.Message}");
-                }
-
-                if (directHandler.Reader.CanGetActions()) {
-                    var actions = directHandler.Reader.GetActions();
-                    foreach (var target in new[] { Sharlayan.Core.Enums.Action.Container.HOTBAR_1, Sharlayan.Core.Enums.Action.Container.HOTBAR_2 }) {
-                        var bar = actions.ActionContainers.FirstOrDefault(c => c.ContainerType == target);
-                        if (bar == null || bar.ActionItems.Count == 0) {
-                            Log($"    Hotbar {target}: (no populated slots)");
-                            continue;
-                        }
-                        Log($"    Hotbar {target} ({bar.ActionItems.Count} populated slots):");
-                        foreach (var item in bar.ActionItems) {
-                            string keybind = string.IsNullOrEmpty(item.KeyBinds) ? "<unbound>" : item.KeyBinds;
-                            Log($"      slot {item.Slot}: \"{item.Name}\" ID={item.ID} keybind=\"{keybind}\"");
-                            string mods = item.Modifiers.Count == 0 ? "(none)" : string.Join("+", item.Modifiers);
-                            Log($"        ActionKey=\"{item.ActionKey ?? string.Empty}\" Modifiers=[{mods}]");
-                            Log($"        Avail={item.IsAvailable} InRange={item.InRange} ChargeReady={item.ChargeReady}/{item.ChargesRemaining} CD={item.CoolDownPercent}% Proc={item.IsProcOrCombo} Cat={item.Category} Icon={item.Icon} Cost={item.RemainingCost}");
-                        }
-                    }
-                }
-                else {
-                    Log("    Hotbar: CanGetActions=false (HOTBAR or RECAST signature missing)");
-                }
-
-                try {
-                    if (directHandler.Reader.CanGetJobResources()) {
-                        var jr = directHandler.Reader.GetJobResources();
-                        var c = jr?.JobResourcesContainer;
-                        if (c != null) {
-                            Log($"    JobResources populated=true  (current job: {dp?.Job})");
-                            Log($"      Bard: ActiveSong={c.Bard.ActiveSong} Timer={c.Bard.Timer}ms Repertoire={c.Bard.Repertoire} SoulVoice={c.Bard.SoulVoice} RadiantFinaleCoda=0x{c.Bard.RadiantFinaleCoda:X2}(b{c.Bard.RadiantFinaleCoda:b3})");
-                        }
-                        else {
-                            Log("    JobResources: Container is null (reader returned empty)");
-                        }
-                    }
-                    else {
-                        Log("    JobResources: CanGetJobResources=false (JOBRESOURCES signature missing)");
-                    }
-                }
-                catch (Exception ex) {
-                    Log($"    ✗ JobResources: {ex.GetType().Name}: {ex.Message}");
-                }
-            }
-            catch (Exception ex) {
-                Log($"    ✗ EyeCheck: {ex.GetType().Name}: {ex.Message}");
-            }
-
-            // [3c.2] GameState — validates GAMEMAIN / CONDITIONS / CONTENTSFINDER / WEATHER /
-            // BGMSYSTEM signatures + Lumina name lookups in one shot.
-            try {
-                if (directHandler.Reader.CanGetGameState()) {
-                    var gs = directHandler.Reader.GetGameState();
-                    Log(string.Empty);
-                    Log("  [3c.2] GAMESTATE");
-                    Log($"    IsLoggedIn={gs.IsLoggedIn}  IsReadyToRead={gs.IsReadyToRead}  TerritoryLoadState={gs.TerritoryLoadState}  (1=loading,2=loaded,3=unloading)");
-                    byte occCut = 0, watch58 = 0, watch78 = 0, bound = 0, occEvt = 0;
-                    if (directHandler.Scanner.Locations.TryGetValue(Sharlayan.Signatures.CONDITIONS_KEY, out var condLoc)) {
-                        IntPtr cond = condLoc;
-                        try { occCut  = directHandler.GetByte(cond, 35); } catch { }
-                        try { watch58 = directHandler.GetByte(cond, 58); } catch { }
-                        try { watch78 = directHandler.GetByte(cond, 78); } catch { }
-                        try { bound   = directHandler.GetByte(cond, 34); } catch { }
-                        try { occEvt  = directHandler.GetByte(cond, 31); } catch { }
-                    }
-                    Log($"    WatchingCutscene={gs.WatchingCutscene}  (raw: OccupiedInCutSceneEvent@35={occCut} WatchingCutscene@58={watch58} WatchingCutscene78@78={watch78} OccupiedInEvent@31={occEvt} BoundByDuty@34={bound})");
-                    Log($"    ContentsFinderQueueState={gs.ContentsFinderQueueState}  (DutyFinderBellPopped={gs.DutyFinderBellPopped}  InInstance={gs.InInstance})");
-                    Log($"    Weather id={gs.CurrentWeatherId}  name=\"{gs.CurrentWeatherName ?? "(no lumina)"}\"");
-                    Log($"    BGM id={gs.CurrentBgmId}  scene={gs.CurrentBgmSceneId}  file=\"{gs.CurrentBgmFile ?? "(no lumina)"}\"");
-                }
-                else {
-                    Log("    GameState: CanGetGameState=false (GAMEMAIN signature didn't resolve)");
-                }
-            }
-            catch (Exception ex) {
-                Log($"    ✗ GameState: {ex.GetType().Name}: {ex.Message}");
-            }
-
-            // [3d] Chat log — validates Framework→UIModule→RaptureLogModule multi-hop
-            // signature AND FCS-derived ChatLogPointers offsets. First call primes the cursor;
-            // (0,0) replays the historical ring buffer; last poll proves the cursor advances.
+            // [3d] Chat log — commented out; re-enable to validate Framework→UIModule→RaptureLogModule chain.
+            /*
             Log(string.Empty);
             Log("  [3d] CHAT LOG");
             try {
@@ -353,13 +210,15 @@ internal static class Program {
             catch (Exception ex) {
                 Log($"    ✗ Chat read: {ex.GetType().Name}: {ex.Message}");
             }
+            */
         }
         catch (Exception ex) {
             Log($"  ✗ Direct scanner failed: {ex.GetType().Name}: {ex.Message}");
         }
         Log(string.Empty);
 
-        // [4] Lumina xivdatabase smoke test -----------------------------------
+        // [4] Lumina xivdatabase smoke test — commented out; re-enable to validate sqpack access.
+        /*
         Log("[4] LUMINA XIVDATABASE VALIDATION");
         try {
             string sqpack = Path.Combine(Path.GetDirectoryName(game.MainModule!.FileName)!, "sqpack");
@@ -391,13 +250,14 @@ internal static class Program {
                         }
                     }
                 }
-                catch { /* best-effort */ }
+                catch { }
             }
         }
         catch (Exception ex) {
             Log($"  ✗ Lumina failed: {ex.GetType().Name}: {ex.Message}");
         }
         Log(string.Empty);
+        */
 
         Log("====== END HARNESS ======");
 
@@ -405,7 +265,236 @@ internal static class Program {
             await File.WriteAllTextAsync(outFilePath, report.ToString());
             Console.WriteLine($"\nReport written to {outFilePath}");
         }
+
+        // Live refresh — the one-shot report above is the snapshot for the file;
+        // this loop lets the user watch eye-check values change in-game. Skipped
+        // when --once is passed (CI / single-shot usage).
+        if (runOnce || directHandler == null) {
+            return 0;
+        }
+
+        await RunLiveRefreshLoop(directHandler, liveIntervalMs);
         return 0;
+    }
+
+    private static async Task RunLiveRefreshLoop(MemoryHandler handler, int intervalMs) {
+        using CancellationTokenSource cts = new();
+        ConsoleCancelEventHandler onCancel = (_, e) => {
+            e.Cancel = true; // suppress default termination; exit loop cleanly
+            cts.Cancel();
+        };
+        Console.CancelKeyPress += onCancel;
+
+        Console.WriteLine();
+        Console.WriteLine($"──── LIVE EYE-CHECK (refresh {intervalMs} ms — Ctrl+C to exit) ────");
+
+        LiveRenderer renderer = new LiveRenderer(Console.CursorTop);
+
+        try {
+            while (!cts.IsCancellationRequested) {
+                Action<string> renderLine = renderer.Begin();
+                renderLine($"tick {DateTime.Now:HH:mm:ss.fff}");
+                try {
+                    RenderEyeCheckAndGameState(handler, renderLine);
+                }
+                catch (Exception ex) {
+                    renderLine($"  ✗ live render failed: {ex.GetType().Name}: {ex.Message}");
+                }
+                renderer.End();
+
+                try {
+                    await Task.Delay(intervalMs, cts.Token);
+                }
+                catch (TaskCanceledException) {
+                    break;
+                }
+            }
+        }
+        finally {
+            Console.CancelKeyPress -= onCancel;
+            // Drop the cursor below the live block so the shell prompt doesn't overwrite it.
+            Console.WriteLine();
+            Console.WriteLine("──── live refresh stopped ────");
+        }
+    }
+
+    /// <summary>
+    /// Draws the [3c.2] GameState block. Called once from the one-shot report pass
+    /// (writes to console + report file) and then repeatedly from the live-refresh
+    /// loop (writes padded lines in place). The earlier [3c] eye-check section is
+    /// kept in source but commented out so the harness focuses on GameState only.
+    /// </summary>
+    private static void RenderEyeCheckAndGameState(MemoryHandler handler, Action<string> log) {
+        // [3c] Eye-check values — commented out; re-enable to surface LocalPlayer / actors /
+        // target / hotbar / job-resource fields for manual UI verification.
+        /*
+        try {
+            var dp = handler.Reader.GetCurrentPlayer()?.Entity;
+            if (dp != null) {
+                log(string.Empty);
+                log("  [3c] EYE-CHECK VALUES");
+                log($"    LocalPlayer.Name       = \"{dp.Name}\"  Job={dp.Job}  Lv={dp.Level}  HP={dp.HPCurrent}/{dp.HPMax}  MP={dp.MPCurrent}/{dp.MPMax}");
+                log($"    LocalPlayer.Pos        = ({dp.X:F2},{dp.Y:F2},{dp.Z:F2})  Heading={dp.Heading:F2}  MapTerritory={dp.MapTerritory}");
+                log($"    LocalPlayer.TargetID   = 0x{dp.TargetID:X8}   (0 when not targeting)");
+                log($"    LocalPlayer.ClaimedByID= 0x{dp.ClaimedByID:X8}   (combat-tag owner; 0 when not in combat)");
+                log($"    LocalPlayer.NPCID1     = {dp.NPCID1}");
+                log($"    LocalPlayer.NPCID2     = {dp.NPCID2}   (NameId — 0 for players, row id for NPCs)");
+                log($"    LocalPlayer.Type       = {dp.Type}   (1=Pc, 2=BattleNpc, 3=EventNpc, 4=Treasure, ...)");
+                log($"    LocalPlayer.TargetFlags= {dp.TargetFlags}   (targetability; see ObjectTargetableFlags)");
+                log($"    LocalPlayer.Title      = {dp.Title}   (TitleId — compare against /title list)");
+                log($"    LocalPlayer.Icon       = {dp.Icon}   (nameplate icon id)");
+                log($"    LocalPlayer.HitBoxRadius={dp.HitBoxRadius}");
+                log($"    LocalPlayer.IsAgroed   = {dp.IsAgroed}   (CharacterData.Flags bit 1 = InCombat; True when engaged)");
+                log($"    LocalPlayer.InCombat   = {dp.InCombat}   (same byte, same bit — should match IsAgroed for local player)");
+                log($"    LocalPlayer.IsAggressive= {dp.IsAggressive}   (bit 0 = IsHostile)");
+                log($"    LocalPlayer.AgroFlags  = 0x{dp.AgroFlags:X2} CombatFlags=0x{dp.CombatFlags:X2}   (bit0=IsHostile bit1=InCombat)");
+                log($"    LocalPlayer.InCutscene = {dp.InCutscene}   (ActorItem.InCutscene — RenderFlags bit; true for cutscenes AND teleports)");
+
+                try {
+                    if (handler.Scanner.Locations.TryGetValue(Sharlayan.Signatures.CHARMAP_KEY, out var charmap)) {
+                        long firstActorAddr = handler.GetInt64(charmap);
+                        if (firstActorAddr != 0) {
+                            IntPtr actor = new IntPtr(firstActorAddr);
+                            byte tgtStatus      = handler.GetByte(actor, 0x95);
+                            byte targetable     = handler.GetByte(actor, 0x9A);
+                            byte renderFlagsLo  = handler.GetByte(actor, 0x118);
+                            byte renderFlagsHi  = handler.GetByte(actor, 0x119);
+                            log($"    LocalPlayer raw @ CHARMAP[0]: TargetStatus@0x95=0x{tgtStatus:X2} TargetableStatus@0x9A=0x{targetable:X2} RenderFlags@0x118=0x{renderFlagsLo:X2} RenderFlags@0x119=0x{renderFlagsHi:X2}");
+                        }
+                    }
+                }
+                catch (Exception ex) {
+                    log($"    ✗ Raw actor byte dump: {ex.GetType().Name}: {ex.Message}");
+                }
+            }
+
+            var dActors2 = handler.Reader.GetActors();
+            var sample = dActors2.CurrentNPCs.Values.Take(3).ToList();
+            foreach (var mob in dActors2.CurrentMonsters.Values.Take(2)) sample.Add(mob);
+            if (sample.Count > 0) {
+                log($"    Sample actors ({sample.Count}):");
+                foreach (var a in sample) {
+                    log($"      - {a.Name,-24} Type={a.Type} ID=0x{a.ID:X8} HP={a.HPCurrent}/{a.HPMax} IsAgroed={a.IsAgroed} AgroFlags=0x{a.AgroFlags:X2}");
+                }
+            }
+
+            try {
+                var tr = handler.Reader.GetTargetInfo();
+                var ti = tr?.TargetInfo;
+                if (ti == null) {
+                    log("    CurrentTarget: (TargetInfo null)");
+                }
+                else {
+                    void DumpTarget(string label, Sharlayan.Core.ActorItem? t) {
+                        if (t == null) { log($"    {label}: (none)"); return; }
+                        log($"    {label}: \"{t.Name}\" Type={t.Type} ID=0x{t.ID:X8} HP={t.HPCurrent}/{t.HPMax}");
+                        log($"      IsAgroed={t.IsAgroed}  AgroFlags=0x{t.AgroFlags:X2}  CombatFlags=0x{t.CombatFlags:X2}  ClaimedByID=0x{t.ClaimedByID:X8}");
+                        log($"      IsCasting={t.IsCasting1}  CastingID={t.CastingID}  CastingProgress={t.CastingProgress:F2}/{t.CastingTime:F2}s  CastTargetID=0x{t.CastingTargetID:X8}");
+                        log($"      Pos=({t.X:F1},{t.Y:F1},{t.Z:F1})  TargetID=0x{t.TargetID:X8}  NPCID2={t.NPCID2}");
+                    }
+                    DumpTarget("CurrentTarget", ti.CurrentTarget);
+                    if (ti.FocusTarget != null) DumpTarget("FocusTarget",   ti.FocusTarget);
+                    if (ti.MouseOverTarget != null) DumpTarget("MouseOverTarget", ti.MouseOverTarget);
+                    if (ti.CurrentTarget == null && ti.FocusTarget == null && ti.MouseOverTarget == null) {
+                        log($"    CurrentTargetID = 0x{ti.CurrentTargetID:X8}  (no resolved target — target offscreen or between actor frames)");
+                    }
+                    if (ti.EnmityItems.Count > 0) {
+                        log($"    EnmityItems ({ti.EnmityItems.Count}):");
+                        foreach (var e in ti.EnmityItems) {
+                            log($"      ID=0x{e.ID:X8}  Enmity={e.Enmity,8}  Name=\"{e.Name}\"");
+                        }
+                    }
+                }
+            }
+            catch (Exception ex) {
+                log($"    ✗ Target: {ex.GetType().Name}: {ex.Message}");
+            }
+
+            if (handler.Reader.CanGetActions()) {
+                var actions = handler.Reader.GetActions();
+                foreach (var target in new[] { Sharlayan.Core.Enums.Action.Container.HOTBAR_1, Sharlayan.Core.Enums.Action.Container.HOTBAR_2 }) {
+                    var bar = actions.ActionContainers.FirstOrDefault(c => c.ContainerType == target);
+                    if (bar == null || bar.ActionItems.Count == 0) {
+                        log($"    Hotbar {target}: (no populated slots)");
+                        continue;
+                    }
+                    log($"    Hotbar {target} ({bar.ActionItems.Count} populated slots):");
+                    foreach (var item in bar.ActionItems) {
+                        string keybind = string.IsNullOrEmpty(item.KeyBinds) ? "<unbound>" : item.KeyBinds;
+                        log($"      slot {item.Slot}: \"{item.Name}\" ID={item.ID} keybind=\"{keybind}\" Avail={item.IsAvailable} InRange={item.InRange} CD={item.CoolDownPercent}% Proc={item.IsProcOrCombo} Charges={item.ChargeReady}/{item.ChargesRemaining}");
+                    }
+                }
+            }
+            else {
+                log("    Hotbar: CanGetActions=false (HOTBAR or RECAST signature missing)");
+            }
+
+            try {
+                if (handler.Reader.CanGetJobResources()) {
+                    var jr = handler.Reader.GetJobResources();
+                    var c = jr?.JobResourcesContainer;
+                    if (c != null) {
+                        log($"    JobResources populated=true  (current job: {dp?.Job})");
+                        log($"      Bard: ActiveSong={c.Bard.ActiveSong} Timer={c.Bard.Timer}ms Repertoire={c.Bard.Repertoire} SoulVoice={c.Bard.SoulVoice} RadiantFinaleCoda=0x{c.Bard.RadiantFinaleCoda:X2}(b{c.Bard.RadiantFinaleCoda:b3})");
+                    }
+                    else {
+                        log("    JobResources: Container is null (reader returned empty)");
+                    }
+                }
+                else {
+                    log("    JobResources: CanGetJobResources=false (JOBRESOURCES signature missing)");
+                }
+            }
+            catch (Exception ex) {
+                log($"    ✗ JobResources: {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+        catch (Exception ex) {
+            log($"    ✗ EyeCheck: {ex.GetType().Name}: {ex.Message}");
+        }
+        */
+
+        // [3c.2] GameState — validates GAMEMAIN / CONDITIONS / CONTENTSFINDER / WEATHER /
+        // BGMSYSTEM signatures + Lumina name lookups in one shot.
+        try {
+            if (handler.Reader.CanGetGameState()) {
+                var gs = handler.Reader.GetGameState();
+                log(string.Empty);
+                log("  [3c.2] GAMESTATE");
+                log($"    IsLoggedIn={gs.IsLoggedIn}  IsReadyToRead={gs.IsReadyToRead}  TerritoryLoadState={gs.TerritoryLoadState}  (1=loading,2=loaded,3=unloading)");
+                log($"    WatchingCutscene={gs.WatchingCutscene}  IsTeleporting={gs.IsTeleporting}");
+                log($"    ContentsFinderQueueState={gs.ContentsFinderQueueState}  (DutyFinderBellPopped={gs.DutyFinderBellPopped}  InInstance={gs.InInstance})");
+                log($"    Weather id={gs.CurrentWeatherId}  name=\"{gs.CurrentWeatherName ?? "(no lumina)"}\"");
+                log($"    BGM playing={gs.CurrentBgmId}  target={gs.CurrentBgmTargetId}  scene={gs.CurrentBgmSceneId}  file=\"{gs.CurrentBgmFile ?? "(no lumina)"}\"");
+                log($"    BGM fadeIn={gs.BgmFadeIn:F2}s  resume={gs.BgmResume:F2}s   (highest non-zero preset across all scenes; fadeIn = delay before audio starts on rising edge)");
+                log($"    IsBgmAudible={gs.IsBgmAudible}   (post-fader — speaker output; muting BGM in-game keeps this false)");
+                if (gs.BgmScenes != null) {
+                    log($"    Scenes ({gs.BgmScenes.Count}):");
+                    foreach (var s in gs.BgmScenes) {
+                        string playing = s.IsPlaying ? s.PlayingBgmId.ToString() : "-";
+                        string target  = s.BgmId == 0 ? "-" : s.BgmId.ToString();
+                        string file    = s.PlayingBgmFile ?? "";
+                        log($"      [{s.Index,2}] {s.SceneType,-10}  playing={playing,-5}  target={target,-5}  isPlaying={s.IsPlaying,-5}  file=\"{file}\"");
+                        // Fade row: custom override first (only set when EnableCustomFade=true),
+                        // then the Lumina preset fallback. PresetFadeInStartTime is the
+                        // delay-before-audio-starts the user is chasing.
+                        log($"           custom: enable={s.EnableCustomFade}  fadeOut={s.FadeOutTime}ms  fadeIn={s.FadeInTime}ms");
+                        log($"           preset: fadeOut={s.PresetFadeOutTime:F2}s  fadeIn={s.PresetFadeInTime:F2}s  fadeInStart={s.PresetFadeInStartTime:F2}s  resume={s.PresetResumeFadeInTime:F2}s");
+                    }
+                }
+            }
+            else {
+                log("    GameState: CanGetGameState=false (GAMEMAIN signature didn't resolve)");
+            }
+        }
+        catch (Exception ex) {
+            log($"    ✗ GameState: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    private static int ParseIntArg(string[] args, string prefix, int fallback) {
+        string? v = args.FirstOrDefault(a => a.StartsWith(prefix))?.Substring(prefix.Length);
+        return int.TryParse(v, out int n) && n > 0 ? n : fallback;
     }
 
     private static void DumpSize<T>(Action<string> log, int? expected = null) where T : unmanaged {
@@ -415,17 +504,46 @@ internal static class Program {
         log($"  {marker} {typeof(T).Name,-35} sizeof=0x{actual:X}{exp}");
     }
 
-    private static void TryRead(Action<string> log, string label, Func<string> body) {
-        try {
-            string result = body();
-            log($"  {label}: {result}");
-        }
-        catch (Exception ex) {
-            log($"  {label}: ✗ {ex.GetType().Name}: {ex.Message}");
-        }
-    }
+    /// <summary>
+    /// In-place line renderer for the live-refresh loop. Captures the cursor row
+    /// once, then on each frame seeks back to it and overwrites lines with
+    /// space-padded content. Pads trailing slots if the current frame is shorter
+    /// than the previous, so ghost lines from a longer prior frame are cleared.
+    /// Each emitted line is truncated to Console.WindowWidth - 1 to prevent
+    /// terminal wrap (which would throw off row math for subsequent lines).
+    /// </summary>
+    private sealed class LiveRenderer {
+        private readonly int _startRow;
+        private int _previousLineCount;
+        private int _thisFrameLineCount;
 
-    private static void Check(string assertion, bool ok, Action<string> log) {
-        log($"    {(ok ? "✓" : "✗")} {assertion}");
+        public LiveRenderer(int startRow) {
+            _startRow = startRow;
+        }
+
+        public Action<string> Begin() {
+            try { Console.SetCursorPosition(0, _startRow); } catch { /* buffer scrolled; give up seeking */ }
+            Console.CursorVisible = false;
+            _thisFrameLineCount = 0;
+            return WriteLine;
+        }
+
+        public void End() {
+            for (int i = _thisFrameLineCount; i < _previousLineCount; i++) {
+                WriteLine(string.Empty);
+            }
+            _previousLineCount = Math.Max(_previousLineCount, _thisFrameLineCount);
+            Console.CursorVisible = true;
+        }
+
+        private void WriteLine(string line) {
+            int width = Math.Max(1, Console.WindowWidth - 1);
+            if (line.Length > width) {
+                line = line.Substring(0, width);
+            }
+            Console.Write(line.PadRight(width));
+            Console.WriteLine();
+            _thisFrameLineCount++;
+        }
     }
 }

--- a/Sharlayan.Tests/Resources/Providers/FCSDependencyIntegrityTests.cs
+++ b/Sharlayan.Tests/Resources/Providers/FCSDependencyIntegrityTests.cs
@@ -58,6 +58,7 @@ namespace Sharlayan.Tests.Resources.Providers {
             "ContentsFinder",
             "WeatherManager",
             "BGMSystem",
+            "SoundManager",
             "Framework",
             "AtkStage",
         };
@@ -123,6 +124,12 @@ namespace Sharlayan.Tests.Resources.Providers {
         public void PrivateFieldOffset_Utf8String_inlineBuffer_Resolves() {
             AssertPrivateFieldExists<Utf8String>("_inlineBuffer");
         }
+
+        [Fact]
+        public void PrivateFieldOffset_SoundManager_FFTBlue1_Resolves() {
+            AssertPrivateFieldExists<FFXIVClientStructs.FFXIV.Client.Sound.SoundManager>("_FFTBlue1");
+        }
+
 
         [Fact]
         public void PrivateFieldOffset_PlayerState_classJobLevels_Resolves() {

--- a/Sharlayan/Models/ReadResults/BgmSceneInfo.cs
+++ b/Sharlayan/Models/ReadResults/BgmSceneInfo.cs
@@ -1,0 +1,127 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="BgmSceneInfo.cs" company="SyndicatedLife">
+//   Copyright© 2007 - 2022 Ryan Wilson <syndicated.life@gmail.com> (https://syndicated.life/)
+//   Licensed under the MIT license. See LICENSE.md in the solution root for full license information.
+// </copyright>
+// <summary>
+//   Per-scene BGM snapshot. <see cref="GameStateResult.BgmScenes"/> exposes one entry per
+//   slot in <c>BGMSystem.Scenes</c> (currently 12). Scenes are priority-ordered: index 0
+//   wins over index 11, so the highest-priority scene with a non-silence PlayingBgmId is
+//   what the user is actually hearing — that's what <see cref="GameStateResult.CurrentBgmId"/>
+//   already surfaces. This array gives downstream consumers visibility into every scene.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Sharlayan.Models.ReadResults {
+    /// <summary>
+    /// Index into <see cref="GameStateResult.BgmScenes"/>. Mirrors the FFXIVClientStructs
+    /// <c>BGMSystem.Scene.SceneId</c> documentation. <see cref="Unknown7"/> and
+    /// <see cref="Unknown8"/> are present for completeness; FCS doesn't have firm names.
+    /// </summary>
+    public enum BgmSceneType {
+        Event = 0,
+        Battle = 1,
+        MiniGame = 2,
+        Content = 3,
+        GFate = 4,
+        Duel = 5,
+        Mount = 6,
+        Unknown7 = 7,
+        Unknown8 = 8,
+        Wedding = 9,
+        Town = 10,
+        Territory = 11,
+    }
+
+    public class BgmSceneInfo {
+        /// <summary>0..11 — same as <see cref="SceneType"/> cast to int.</summary>
+        public int Index { get; internal set; }
+
+        /// <summary>Named slot — see <see cref="BgmSceneType"/> for the priority order.</summary>
+        public BgmSceneType SceneType { get; internal set; }
+
+        /// <summary>
+        /// <c>Scene.BgmId</c> — the *intended* track for this scene. May differ from
+        /// <see cref="PlayingBgmId"/> mid-BGMSwitch and converges once the swap completes.
+        /// </summary>
+        public ushort BgmId { get; internal set; }
+
+        /// <summary>
+        /// <c>Scene.PlayingBgmId</c> — the track actually selected on this scene. Note id 0
+        /// means "no track" and id 1 is FFXIV's silence sentinel; both are treated as
+        /// not-playing by <see cref="IsPlaying"/>.
+        /// </summary>
+        public ushort PlayingBgmId { get; internal set; }
+
+        /// <summary>
+        /// <c>Scene.PreviousBgmId</c>. FCS comment: "holds BgmId until after BGMSwitch
+        /// selection" — useful for tracking transitions.
+        /// </summary>
+        public ushort PreviousBgmId { get; internal set; }
+
+        /// <summary>
+        /// True iff <see cref="PlayingBgmId"/> is non-zero AND not the silence sentinel
+        /// (id=1). Cheap convenience over the raw id.
+        /// </summary>
+        public bool IsPlaying => this.PlayingBgmId != 0 && this.PlayingBgmId != 1;
+
+        /// <summary>
+        /// Lumina-resolved file path for <see cref="PlayingBgmId"/> (e.g.
+        /// "music/ffxiv/BGM_Field_Gri_Day.scd"). Null when <see cref="IsPlaying"/> is false
+        /// or when sqpack/Lumina isn't available.
+        /// </summary>
+        public string PlayingBgmFile { get; internal set; }
+
+        /// <summary>
+        /// <c>Scene.PlayState</c> — manual control flag set by <c>BGMSystem.SetBGMPlayState</c>.
+        /// 0 = Paused, 1 = Playing. Note the game does *not* write this during normal
+        /// playback; expect it to stay 0 for most scenes. Exposed for completeness.
+        /// </summary>
+        public byte PlayState { get; internal set; }
+
+        /// <summary>
+        /// <c>Scene.EnableCustomFade</c> — true when the per-scene fade overrides
+        /// (<see cref="FadeOutTime"/> / <see cref="FadeInTime"/>) are populated. When
+        /// false, the game uses defaults from the BGMFadeType Excel sheet and the local
+        /// fade fields stay at 0.
+        /// </summary>
+        public bool EnableCustomFade { get; internal set; }
+
+        /// <summary>Per-scene fade-out duration override (ms). Only meaningful when <see cref="EnableCustomFade"/> is true.</summary>
+        public uint FadeOutTime { get; internal set; }
+
+        /// <summary>Per-scene fade-in duration override (ms). Only meaningful when <see cref="EnableCustomFade"/> is true.</summary>
+        public uint FadeInTime { get; internal set; }
+
+        // --- Lumina-resolved preset fades ---------------------------------------------
+        // When EnableCustomFade is false (the common case), the game uses fade durations
+        // from the BGMFade Excel sheet, keyed on (SceneOut, SceneIn). The Preset* fields
+        // below are filled from the FIRST BGMFade row whose SceneIn matches this scene's
+        // Index — i.e. the "fade-in for transitioning *into* this scene." Values are
+        // in seconds (Lumina float). Zero when sqpack is unavailable or no row matches.
+
+        /// <summary><c>BGMFadeType.FadeOutTime</c> (seconds) for the preset fade-into-this-scene row.</summary>
+        public float PresetFadeOutTime { get; internal set; }
+
+        /// <summary>
+        /// <c>BGMFadeType.FadeInTime</c> (seconds) — duration of the volume ramp once fade-in
+        /// actually begins.
+        /// </summary>
+        public float PresetFadeInTime { get; internal set; }
+
+        /// <summary>
+        /// <c>BGMFadeType.FadeInStartTime</c> (seconds) — delay between the scene's
+        /// PlayingBgmId becoming non-zero and the audio starting its ramp. This is the
+        /// "delayed start" you observe when IsPlaying flips true before audio is heard:
+        /// audible at <c>(IsPlaying rising edge) + PresetFadeInStartTime</c>, full volume
+        /// at <c>(rising edge) + PresetFadeInStartTime + PresetFadeInTime</c>.
+        /// </summary>
+        public float PresetFadeInStartTime { get; internal set; }
+
+        /// <summary>
+        /// <c>BGMFadeType.ResumeFadeInTime</c> (seconds) — used when resuming a previously
+        /// paused track rather than starting fresh.
+        /// </summary>
+        public float PresetResumeFadeInTime { get; internal set; }
+    }
+}

--- a/Sharlayan/Models/ReadResults/GameStateResult.cs
+++ b/Sharlayan/Models/ReadResults/GameStateResult.cs
@@ -14,6 +14,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 namespace Sharlayan.Models.ReadResults {
+    using System.Collections.Generic;
+
     public class GameStateResult {
         // --- Session & readiness -------------------------------------------------------
         public bool IsLoggedIn { get; internal set; }
@@ -55,13 +57,82 @@ namespace Sharlayan.Models.ReadResults {
         public string CurrentWeatherName { get; internal set; }
 
         // --- Music ---------------------------------------------------------------------
-        /// <summary>Highest-priority scene's PlayingBgmId (walks BGMSystem.Scenes 0..N). 0 if no scene is playing.</summary>
+        /// <summary>
+        /// Sourced from <c>Scene.PlayingBgmId</c> on the highest-priority scene currently
+        /// playing audible audio (walks BGMSystem.Scenes 0..N skipping scenes parked on
+        /// id=0 or id=1 silence sentinel). 0 if no scene has audible audio.
+        /// </summary>
         public ushort CurrentBgmId { get; internal set; }
+
+        /// <summary>
+        /// Sourced from <c>Scene.BgmId</c> (the "intended" track) on the same winning scene
+        /// as <see cref="CurrentBgmId"/>. When <c>CurrentBgmTargetId != CurrentBgmId</c> the
+        /// scene is mid-BGMSwitch — useful as a "BGM transition in progress" signal that
+        /// settles at the new value once the swap completes.
+        /// </summary>
+        public ushort CurrentBgmTargetId { get; internal set; }
+
+        /// <summary>
+        /// One <see cref="BgmSceneInfo"/> per slot in <c>BGMSystem.Scenes</c> (currently 12,
+        /// indexed via <see cref="BgmSceneType"/>). Scenes are priority-ordered: index 0
+        /// (Event) wins over index 11 (Territory). The "winning" scene's values are also
+        /// exposed flat as <see cref="CurrentBgmId"/> / <see cref="CurrentBgmTargetId"/> /
+        /// <see cref="CurrentBgmSceneId"/> / <see cref="CurrentBgmFile"/>; this array gives
+        /// downstream consumers visibility into every layer (e.g. the Battle scene track
+        /// while an Event scene is also active).
+        /// <para>
+        /// Empty if BGMSYSTEM didn't resolve. Always 12 elements when populated.
+        /// </para>
+        /// </summary>
+        public IReadOnlyList<BgmSceneInfo> BgmScenes { get; internal set; }
 
         /// <summary>BGMScene row index that's currently playing (0 = Event, 1 = Battle, ..., 11 = Territory). -1 if none.</summary>
         public int CurrentBgmSceneId { get; internal set; } = -1;
 
         /// <summary>BGM file path from the BGM sheet (e.g. "music/ffxiv/BGM_Field_Gri_Day.scd"); null if unavailable.</summary>
         public string CurrentBgmFile { get; internal set; }
+
+        /// <summary>
+        /// Highest non-zero <c>BGMFadeType.FadeInStartTime</c> (seconds) across every entry
+        /// in <see cref="BgmScenes"/>. This is the *delay* between a scene's PlayingBgmId
+        /// becoming non-zero and audio actually starting its volume ramp; the longest such
+        /// delay among all scenes is what determines when the user will hear the new track.
+        /// Zero scenes don't contribute — a single scene with a 0.5s start delay wins over
+        /// many scenes at 0. 0 if all scenes are 0 or sqpack/Lumina isn't available.
+        /// </summary>
+        public float BgmFadeIn { get; internal set; }
+
+        /// <summary>
+        /// Highest non-zero <c>BGMFadeType.ResumeFadeInTime</c> (seconds) across every
+        /// entry in <see cref="BgmScenes"/>. Used by the game when resuming a previously
+        /// paused track rather than starting fresh. Zero entries are skipped. 0 if all
+        /// scenes are 0 or sqpack/Lumina isn't available.
+        /// </summary>
+        public float BgmResume { get; internal set; }
+
+        /// <summary>
+        /// True if any active SoundData entry has IsLoadingSoundResource set. Walked from
+        /// SoundManager.ActiveSoundDataListHead following ISoundData.Next. This is a coarse
+        /// "audio engine is loading something right now" signal — during a BGM transition
+        /// (zone change, scene swap) the new BGM SoundData briefly raises this flag, so it
+        /// works as a proxy for "BGM is transitioning". Returns false during steady-state
+        /// playback. Set to false if SoundManager isn't resolved.
+        /// </summary>
+        public bool AnySoundLoading { get; internal set; }
+
+        /// <summary>
+        /// True when audible audio energy is present on the *music* bus specifically
+        /// (sourced from <c>SoundManager._FFTBlue1</c> — FCS labels Blue as the Music bus,
+        /// distinct from Red=System and Green=SE/Voice/Instruments).
+        /// <para>
+        /// <b>Post-master-volume</b> — this is the speaker output, so muting BGM in-game or
+        /// dropping the slider to 0 will keep this false even when music is playing in the
+        /// audio engine. For a pre-fader signal that ignores user volume settings, consume
+        /// <see cref="BgmScenes"/> directly (a non-zero <c>PlayingBgmId</c> on any scene means
+        /// the audio engine has selected a track regardless of user volume).
+        /// </para>
+        /// Set to false if SoundManager isn't resolved.
+        /// </summary>
+        public bool IsBgmAudible { get; internal set; }
     }
 }

--- a/Sharlayan/Reader.GameState.cs
+++ b/Sharlayan/Reader.GameState.cs
@@ -18,6 +18,7 @@ namespace Sharlayan {
 
     using FCSGame = FFXIVClientStructs.FFXIV.Client.Game;
     using FCSGameUI = FFXIVClientStructs.FFXIV.Client.Game.UI;
+    using FCSSound = FFXIVClientStructs.FFXIV.Client.Sound;
 
     using Sharlayan.Models.ReadResults;
     using Sharlayan.Resources.Mappers;
@@ -41,6 +42,24 @@ namespace Sharlayan {
         private static readonly int BGMSystemScenesOffset = FieldOffsetReader.OffsetOf<FCSGame.BGMSystem>(nameof(FCSGame.BGMSystem.Scenes));
         private static readonly int BGMSceneSize = FieldOffsetReader.SizeOf<FCSGame.BGMSystem.Scene>();
         private static readonly int BGMScenePlayingBgmIdOffset = FieldOffsetReader.OffsetOf<FCSGame.BGMSystem.Scene>(nameof(FCSGame.BGMSystem.Scene.PlayingBgmId));
+        private static readonly int BGMSceneBgmIdOffset = FieldOffsetReader.OffsetOf<FCSGame.BGMSystem.Scene>(nameof(FCSGame.BGMSystem.Scene.BgmId));
+        private static readonly int BGMScenePreviousBgmIdOffset = FieldOffsetReader.OffsetOf<FCSGame.BGMSystem.Scene>(nameof(FCSGame.BGMSystem.Scene.PreviousBgmId));
+        private static readonly int BGMScenePlayStateOffset = FieldOffsetReader.OffsetOf<FCSGame.BGMSystem.Scene>(nameof(FCSGame.BGMSystem.Scene.PlayState));
+        private static readonly int BGMSceneEnableCustomFadeOffset = FieldOffsetReader.OffsetOf<FCSGame.BGMSystem.Scene>(nameof(FCSGame.BGMSystem.Scene.EnableCustomFade));
+        private static readonly int BGMSceneFadeOutTimeOffset = FieldOffsetReader.OffsetOf<FCSGame.BGMSystem.Scene>(nameof(FCSGame.BGMSystem.Scene.FadeOutTime));
+        private static readonly int BGMSceneFadeInTimeOffset = FieldOffsetReader.OffsetOf<FCSGame.BGMSystem.Scene>(nameof(FCSGame.BGMSystem.Scene.FadeInTime));
+        private static readonly int SoundManagerActiveSoundDataListHeadOffset = FieldOffsetReader.OffsetOf<FCSSound.SoundManager>(nameof(FCSSound.SoundManager.ActiveSoundDataListHead));
+        private static readonly int ISoundDataNextOffset = FieldOffsetReader.OffsetOf<FCSSound.ISoundData>(nameof(FCSSound.ISoundData.Next));
+        private static readonly int SoundDataIsLoadingSoundResourceOffset = FieldOffsetReader.OffsetOf<FCSSound.SoundData>(nameof(FCSSound.SoundData.IsLoadingSoundResource));
+        // FCS labels SoundManager's FFT arrays by colour: Red=System, Green=SE/Voice/Instruments,
+        // Blue=Music. Each is a 256-element float array of frequency-domain energy refreshed
+        // every game frame; Blue1 carries the post-mix output for the music bus, so reading any
+        // bin > 0 means audible music. We sample only the first 8 low-frequency bins (32 bytes)
+        // — music carries most of its energy there and SFX-bleed-through stays out. Field is
+        // private (`_FFTBlue1`) in FCS so we resolve it via string-name lookup.
+        private static readonly int SoundManagerFFTBlue1Offset = FieldOffsetReader.OffsetOf<FCSSound.SoundManager>("_FFTBlue1");
+        private const int BgmAudibleBinCount = 8;
+        private const float BgmAudibleEpsilon = 0.0001f;
         // StdVector<T> layout is fixed C++ ABI contract: (T* First, T* Last, T* End) at 0/8/16.
         private const int StdVectorFirstOffset = 0;
         private const int StdVectorLastOffset = 8;
@@ -52,6 +71,11 @@ namespace Sharlayan {
         // Lumina open failed.
         private Lumina.Excel.ExcelSheet<Lumina.Excel.Sheets.Weather> _weatherSheetEn;
         private Lumina.Excel.ExcelSheet<Lumina.Excel.Sheets.BGM> _bgmSheetEn;
+        // Per-scene fade preset cache: scene index 0..11 → BGMFadeType row id (0 = none).
+        // Populated on first sheet resolution by walking BGMFade rows and matching SceneIn.
+        // BGMFade is small (a few dozen rows) and static, so this is one-shot work.
+        private uint[] _scenePresetFadeTypeRowIds;
+        private Lumina.Excel.ExcelSheet<Lumina.Excel.Sheets.BGMFadeType> _bgmFadeTypeSheet;
         private bool _sheetsAttempted;
 
         public bool CanGetGameState() {
@@ -127,7 +151,9 @@ namespace Sharlayan {
 
             // --- BGMSystem.Scenes StdVector, iterate 0..N ---
             // Scenes are priority-ordered — scene 0 (Event) wins over scene 11 (Territory),
-            // so the first non-zero PlayingBgmId as we walk the vector is what the user is hearing.
+            // so the first non-silence PlayingBgmId as we walk the vector is what the user is
+            // hearing (CurrentBgmId/SceneId/TargetId). The full per-scene snapshot lands in
+            // result.BgmScenes for downstream consumers that need every layer.
             if (locations.ContainsKey(Signatures.BGMSYSTEM_KEY)) {
                 IntPtr bgmSystem = locations[Signatures.BGMSYSTEM_KEY];
                 try {
@@ -136,23 +162,76 @@ namespace Sharlayan {
                     if (first != 0 && last > first) {
                         int sceneCount = (int)((last - first) / BGMSceneSize);
                         if (sceneCount > 12) sceneCount = 12; // cap — 12 documented scene types.
+                        var scenes = new BgmSceneInfo[sceneCount];
                         for (int i = 0; i < sceneCount; i++) {
                             IntPtr sceneAddr = new IntPtr(first + i * BGMSceneSize);
-                            ushort playing = this._memoryHandler.GetUInt16(sceneAddr, BGMScenePlayingBgmIdOffset);
+                            BgmSceneInfo info = new BgmSceneInfo {
+                                Index = i,
+                                SceneType = (BgmSceneType)i,
+                            };
+                            try { info.PlayingBgmId      = this._memoryHandler.GetUInt16(sceneAddr, BGMScenePlayingBgmIdOffset); } catch { }
+                            try { info.BgmId             = this._memoryHandler.GetUInt16(sceneAddr, BGMSceneBgmIdOffset); }        catch { }
+                            try { info.PreviousBgmId    = this._memoryHandler.GetUInt16(sceneAddr, BGMScenePreviousBgmIdOffset); } catch { }
+                            try { info.PlayState         = (byte)this._memoryHandler.GetUInt32(sceneAddr, BGMScenePlayStateOffset); } catch { }
+                            try { info.EnableCustomFade  = this._memoryHandler.GetByte(sceneAddr, BGMSceneEnableCustomFadeOffset) != 0; } catch { }
+                            try { info.FadeOutTime       = this._memoryHandler.GetUInt32(sceneAddr, BGMSceneFadeOutTimeOffset); } catch { }
+                            try { info.FadeInTime        = this._memoryHandler.GetUInt32(sceneAddr, BGMSceneFadeInTimeOffset); }  catch { }
+                            scenes[i] = info;
+
                             // BGM id 1 is FFXIV's silence sentinel — a scene playing id=1 is
-                            // actively suppressing audio, not "nothing playing". Skip it so the walk
-                            // falls through to the next-priority scene with real audio (e.g. an Event
-                            // scene parked on silence during a fight would otherwise mask the Battle
-                            // scene's actual track).
-                            if (playing != 0 && playing != 1) {
-                                result.CurrentBgmId = playing;
+                            // actively suppressing audio, not "nothing playing". Skip it so the
+                            // priority walk falls through to the next-priority scene with real
+                            // audio (e.g. an Event scene parked on silence during a fight would
+                            // otherwise mask the Battle scene's actual track).
+                            if (result.CurrentBgmId == 0 && info.PlayingBgmId != 0 && info.PlayingBgmId != 1) {
+                                result.CurrentBgmId      = info.PlayingBgmId;
                                 result.CurrentBgmSceneId = i;
-                                break;
+                                result.CurrentBgmTargetId = info.BgmId;
                             }
                         }
+                        result.BgmScenes = scenes;
                     }
                 }
                 catch { /* ignore */ }
+            }
+
+            // --- SoundManager.ActiveSoundDataListHead walk for AnySoundLoading ---
+            // Each list node is a SoundData (which inherits ISoundData; ISoundData.Next is at
+            // +0x18 and lives at the same offset within SoundData by single-inheritance layout).
+            // We OR all IsLoadingSoundResource bytes — coarse "audio engine is loading" signal,
+            // most useful as a "BGM transitioning" proxy during zone changes / scene swaps.
+            if (locations.ContainsKey(Signatures.SOUNDMANAGER_KEY)) {
+                IntPtr soundManager = locations[Signatures.SOUNDMANAGER_KEY];
+                try {
+                    long head = this._memoryHandler.GetInt64(soundManager, SoundManagerActiveSoundDataListHeadOffset);
+                    // Pool is bounded at 256 SoundData entries (SoundDataMemory). Cap loop at 512
+                    // as a safety belt against corrupted Next pointers / list cycles.
+                    int safety = 512;
+                    while (head != 0 && safety-- > 0) {
+                        IntPtr soundData = new IntPtr(head);
+                        byte loading = this._memoryHandler.GetByte(soundData, SoundDataIsLoadingSoundResourceOffset);
+                        if (loading != 0) {
+                            result.AnySoundLoading = true;
+                            break;
+                        }
+                        head = this._memoryHandler.GetInt64(soundData, ISoundDataNextOffset);
+                    }
+                }
+                catch { /* ignore */ }
+
+                // IsBgmAudible — speaker output energy on the music bus. POST-master-volume,
+                // so a muted music slider keeps this false; downstream apps that need a
+                // pre-fader signal can consume Scene.PlayingBgmId on result.BgmScenes instead.
+                try {
+                    IntPtr fftAddr = new IntPtr(soundManager.ToInt64() + SoundManagerFFTBlue1Offset);
+                    byte[] fftBytes = this._memoryHandler.GetByteArray(fftAddr, BgmAudibleBinCount * sizeof(float));
+                    float energy = 0f;
+                    for (int i = 0; i < BgmAudibleBinCount; i++) {
+                        energy += Math.Abs(BitConverter.ToSingle(fftBytes, i * sizeof(float)));
+                    }
+                    result.IsBgmAudible = energy > BgmAudibleEpsilon;
+                }
+                catch { /* leave false */ }
             }
 
             // --- Lumina name resolution (best-effort; silently skipped if sqpack not found) ---
@@ -163,6 +242,42 @@ namespace Sharlayan {
                 }
                 if (this._bgmSheetEn != null && result.CurrentBgmId != 0 && this._bgmSheetEn.HasRow(result.CurrentBgmId)) {
                     result.CurrentBgmFile = this._bgmSheetEn.GetRow(result.CurrentBgmId).File.ExtractText();
+                }
+                // Per-scene file + preset-fade resolution.
+                if (result.BgmScenes != null) {
+                    foreach (BgmSceneInfo info in result.BgmScenes) {
+                        if (info == null) continue;
+                        if (this._bgmSheetEn != null && info.IsPlaying && this._bgmSheetEn.HasRow(info.PlayingBgmId)) {
+                            info.PlayingBgmFile = this._bgmSheetEn.GetRow(info.PlayingBgmId).File.ExtractText();
+                        }
+                        // BGMFade preset lookup — scene → first matching BGMFadeType.
+                        if (this._bgmFadeTypeSheet != null && this._scenePresetFadeTypeRowIds != null
+                            && info.Index >= 0 && info.Index < this._scenePresetFadeTypeRowIds.Length) {
+                            uint fadeTypeId = this._scenePresetFadeTypeRowIds[info.Index];
+                            if (fadeTypeId != 0 && this._bgmFadeTypeSheet.HasRow(fadeTypeId)) {
+                                var ft = this._bgmFadeTypeSheet.GetRow(fadeTypeId);
+                                info.PresetFadeOutTime      = ft.FadeOutTime;
+                                info.PresetFadeInTime       = ft.FadeInTime;
+                                info.PresetFadeInStartTime  = ft.FadeInStartTime;
+                                info.PresetResumeFadeInTime = ft.ResumeFadeInTime;
+                            }
+                        }
+                    }
+
+                    // Highest non-zero preset values across every scene, surfaced flat on the
+                    // result so consumers don't have to re-walk BgmScenes. Zero entries
+                    // (scenes with no Lumina preset) are skipped — only meaningful values
+                    // contribute, so a single scene with a 0.5s start delay wins over many
+                    // scenes left at 0.
+                    foreach (BgmSceneInfo info in result.BgmScenes) {
+                        if (info == null) continue;
+                        if (info.PresetFadeInStartTime > result.BgmFadeIn) {
+                            result.BgmFadeIn = info.PresetFadeInStartTime;
+                        }
+                        if (info.PresetResumeFadeInTime > result.BgmResume) {
+                            result.BgmResume = info.PresetResumeFadeInTime;
+                        }
+                    }
                 }
             }
             catch { /* Lumina failures shouldn't break the numeric result */ }
@@ -184,6 +299,21 @@ namespace Sharlayan {
             try {
                 this._weatherSheetEn = lumina.Excel.GetSheet<Lumina.Excel.Sheets.Weather>();
                 this._bgmSheetEn = lumina.Excel.GetSheet<Lumina.Excel.Sheets.BGM>();
+                this._bgmFadeTypeSheet = lumina.Excel.GetSheet<Lumina.Excel.Sheets.BGMFadeType>();
+
+                // Build the scene → BGMFadeType lookup once. BGMFade has (SceneOut, SceneIn,
+                // BGMFadeType) triples — we pick the FIRST row whose SceneIn matches each
+                // scene index 0..11. Multiple rows may match (different SceneOut origins);
+                // first match is a pragmatic default that surfaces a representative preset.
+                var bgmFadeSheet = lumina.Excel.GetSheet<Lumina.Excel.Sheets.BGMFade>();
+                this._scenePresetFadeTypeRowIds = new uint[12];
+                foreach (var row in bgmFadeSheet) {
+                    int sceneIn = row.SceneIn;
+                    if (sceneIn >= 0 && sceneIn < this._scenePresetFadeTypeRowIds.Length
+                        && this._scenePresetFadeTypeRowIds[sceneIn] == 0) {
+                        this._scenePresetFadeTypeRowIds[sceneIn] = row.BGMFadeType.RowId;
+                    }
+                }
             }
             catch { /* leave fields null; subsequent calls skip the lookup */ }
         }

--- a/Sharlayan/Resources/Providers/FFXIVClientStructsDirectProvider.cs
+++ b/Sharlayan/Resources/Providers/FFXIVClientStructsDirectProvider.cs
@@ -122,6 +122,7 @@ namespace Sharlayan.Resources.Providers {
             TryAdd(signatures, Signatures.CONTENTSFINDER_KEY, "ContentsFinder", 0);
             TryAdd(signatures, Signatures.WEATHER_KEY,        "WeatherManager", 0);
             TryAdd(signatures, Signatures.BGMSYSTEM_KEY,      "BGMSystem",      0);
+            TryAdd(signatures, Signatures.SOUNDMANAGER_KEY,   "SoundManager",   0);
 
             // --- Multi-hop chains ------------------------------------------------------
             // CHATLOG: Framework (isPointer=true) → UIModule* @ Framework.UIModule → trailing

--- a/Sharlayan/Sharlayan.xml
+++ b/Sharlayan/Sharlayan.xml
@@ -54,6 +54,96 @@
             message timestamp
             </summary>
         </member>
+        <member name="T:Sharlayan.Models.ReadResults.BgmSceneType">
+            <summary>
+            Index into <see cref="P:Sharlayan.Models.ReadResults.GameStateResult.BgmScenes"/>. Mirrors the FFXIVClientStructs
+            <c>BGMSystem.Scene.SceneId</c> documentation. <see cref="F:Sharlayan.Models.ReadResults.BgmSceneType.Unknown7"/> and
+            <see cref="F:Sharlayan.Models.ReadResults.BgmSceneType.Unknown8"/> are present for completeness; FCS doesn't have firm names.
+            </summary>
+        </member>
+        <member name="P:Sharlayan.Models.ReadResults.BgmSceneInfo.Index">
+            <summary>0..11 — same as <see cref="P:Sharlayan.Models.ReadResults.BgmSceneInfo.SceneType"/> cast to int.</summary>
+        </member>
+        <member name="P:Sharlayan.Models.ReadResults.BgmSceneInfo.SceneType">
+            <summary>Named slot — see <see cref="T:Sharlayan.Models.ReadResults.BgmSceneType"/> for the priority order.</summary>
+        </member>
+        <member name="P:Sharlayan.Models.ReadResults.BgmSceneInfo.BgmId">
+            <summary>
+            <c>Scene.BgmId</c> — the *intended* track for this scene. May differ from
+            <see cref="P:Sharlayan.Models.ReadResults.BgmSceneInfo.PlayingBgmId"/> mid-BGMSwitch and converges once the swap completes.
+            </summary>
+        </member>
+        <member name="P:Sharlayan.Models.ReadResults.BgmSceneInfo.PlayingBgmId">
+            <summary>
+            <c>Scene.PlayingBgmId</c> — the track actually selected on this scene. Note id 0
+            means "no track" and id 1 is FFXIV's silence sentinel; both are treated as
+            not-playing by <see cref="P:Sharlayan.Models.ReadResults.BgmSceneInfo.IsPlaying"/>.
+            </summary>
+        </member>
+        <member name="P:Sharlayan.Models.ReadResults.BgmSceneInfo.PreviousBgmId">
+            <summary>
+            <c>Scene.PreviousBgmId</c>. FCS comment: "holds BgmId until after BGMSwitch
+            selection" — useful for tracking transitions.
+            </summary>
+        </member>
+        <member name="P:Sharlayan.Models.ReadResults.BgmSceneInfo.IsPlaying">
+            <summary>
+            True iff <see cref="P:Sharlayan.Models.ReadResults.BgmSceneInfo.PlayingBgmId"/> is non-zero AND not the silence sentinel
+            (id=1). Cheap convenience over the raw id.
+            </summary>
+        </member>
+        <member name="P:Sharlayan.Models.ReadResults.BgmSceneInfo.PlayingBgmFile">
+            <summary>
+            Lumina-resolved file path for <see cref="P:Sharlayan.Models.ReadResults.BgmSceneInfo.PlayingBgmId"/> (e.g.
+            "music/ffxiv/BGM_Field_Gri_Day.scd"). Null when <see cref="P:Sharlayan.Models.ReadResults.BgmSceneInfo.IsPlaying"/> is false
+            or when sqpack/Lumina isn't available.
+            </summary>
+        </member>
+        <member name="P:Sharlayan.Models.ReadResults.BgmSceneInfo.PlayState">
+            <summary>
+            <c>Scene.PlayState</c> — manual control flag set by <c>BGMSystem.SetBGMPlayState</c>.
+            0 = Paused, 1 = Playing. Note the game does *not* write this during normal
+            playback; expect it to stay 0 for most scenes. Exposed for completeness.
+            </summary>
+        </member>
+        <member name="P:Sharlayan.Models.ReadResults.BgmSceneInfo.EnableCustomFade">
+            <summary>
+            <c>Scene.EnableCustomFade</c> — true when the per-scene fade overrides
+            (<see cref="P:Sharlayan.Models.ReadResults.BgmSceneInfo.FadeOutTime"/> / <see cref="P:Sharlayan.Models.ReadResults.BgmSceneInfo.FadeInTime"/>) are populated. When
+            false, the game uses defaults from the BGMFadeType Excel sheet and the local
+            fade fields stay at 0.
+            </summary>
+        </member>
+        <member name="P:Sharlayan.Models.ReadResults.BgmSceneInfo.FadeOutTime">
+            <summary>Per-scene fade-out duration override (ms). Only meaningful when <see cref="P:Sharlayan.Models.ReadResults.BgmSceneInfo.EnableCustomFade"/> is true.</summary>
+        </member>
+        <member name="P:Sharlayan.Models.ReadResults.BgmSceneInfo.FadeInTime">
+            <summary>Per-scene fade-in duration override (ms). Only meaningful when <see cref="P:Sharlayan.Models.ReadResults.BgmSceneInfo.EnableCustomFade"/> is true.</summary>
+        </member>
+        <member name="P:Sharlayan.Models.ReadResults.BgmSceneInfo.PresetFadeOutTime">
+            <summary><c>BGMFadeType.FadeOutTime</c> (seconds) for the preset fade-into-this-scene row.</summary>
+        </member>
+        <member name="P:Sharlayan.Models.ReadResults.BgmSceneInfo.PresetFadeInTime">
+            <summary>
+            <c>BGMFadeType.FadeInTime</c> (seconds) — duration of the volume ramp once fade-in
+            actually begins.
+            </summary>
+        </member>
+        <member name="P:Sharlayan.Models.ReadResults.BgmSceneInfo.PresetFadeInStartTime">
+            <summary>
+            <c>BGMFadeType.FadeInStartTime</c> (seconds) — delay between the scene's
+            PlayingBgmId becoming non-zero and the audio starting its ramp. This is the
+            "delayed start" you observe when IsPlaying flips true before audio is heard:
+            audible at <c>(IsPlaying rising edge) + PresetFadeInStartTime</c>, full volume
+            at <c>(rising edge) + PresetFadeInStartTime + PresetFadeInTime</c>.
+            </summary>
+        </member>
+        <member name="P:Sharlayan.Models.ReadResults.BgmSceneInfo.PresetResumeFadeInTime">
+            <summary>
+            <c>BGMFadeType.ResumeFadeInTime</c> (seconds) — used when resuming a previously
+            paused track rather than starting fresh.
+            </summary>
+        </member>
         <member name="P:Sharlayan.Models.ReadResults.GameStateResult.TerritoryLoadState">
             <summary>GameMain.TerritoryLoadState raw byte: 1 = loading, 2 = loaded, 3 = unloading.</summary>
         </member>
@@ -87,13 +177,82 @@
             <summary>Localised name from the Weather sheet; null if GameInstallPath wasn't set or the row is missing.</summary>
         </member>
         <member name="P:Sharlayan.Models.ReadResults.GameStateResult.CurrentBgmId">
-            <summary>Highest-priority scene's PlayingBgmId (walks BGMSystem.Scenes 0..N). 0 if no scene is playing.</summary>
+            <summary>
+            Sourced from <c>Scene.PlayingBgmId</c> on the highest-priority scene currently
+            playing audible audio (walks BGMSystem.Scenes 0..N skipping scenes parked on
+            id=0 or id=1 silence sentinel). 0 if no scene has audible audio.
+            </summary>
+        </member>
+        <member name="P:Sharlayan.Models.ReadResults.GameStateResult.CurrentBgmTargetId">
+            <summary>
+            Sourced from <c>Scene.BgmId</c> (the "intended" track) on the same winning scene
+            as <see cref="P:Sharlayan.Models.ReadResults.GameStateResult.CurrentBgmId"/>. When <c>CurrentBgmTargetId != CurrentBgmId</c> the
+            scene is mid-BGMSwitch — useful as a "BGM transition in progress" signal that
+            settles at the new value once the swap completes.
+            </summary>
+        </member>
+        <member name="P:Sharlayan.Models.ReadResults.GameStateResult.BgmScenes">
+            <summary>
+            One <see cref="T:Sharlayan.Models.ReadResults.BgmSceneInfo"/> per slot in <c>BGMSystem.Scenes</c> (currently 12,
+            indexed via <see cref="T:Sharlayan.Models.ReadResults.BgmSceneType"/>). Scenes are priority-ordered: index 0
+            (Event) wins over index 11 (Territory). The "winning" scene's values are also
+            exposed flat as <see cref="P:Sharlayan.Models.ReadResults.GameStateResult.CurrentBgmId"/> / <see cref="P:Sharlayan.Models.ReadResults.GameStateResult.CurrentBgmTargetId"/> /
+            <see cref="P:Sharlayan.Models.ReadResults.GameStateResult.CurrentBgmSceneId"/> / <see cref="P:Sharlayan.Models.ReadResults.GameStateResult.CurrentBgmFile"/>; this array gives
+            downstream consumers visibility into every layer (e.g. the Battle scene track
+            while an Event scene is also active).
+            <para>
+            Empty if BGMSYSTEM didn't resolve. Always 12 elements when populated.
+            </para>
+            </summary>
         </member>
         <member name="P:Sharlayan.Models.ReadResults.GameStateResult.CurrentBgmSceneId">
             <summary>BGMScene row index that's currently playing (0 = Event, 1 = Battle, ..., 11 = Territory). -1 if none.</summary>
         </member>
         <member name="P:Sharlayan.Models.ReadResults.GameStateResult.CurrentBgmFile">
             <summary>BGM file path from the BGM sheet (e.g. "music/ffxiv/BGM_Field_Gri_Day.scd"); null if unavailable.</summary>
+        </member>
+        <member name="P:Sharlayan.Models.ReadResults.GameStateResult.BgmFadeIn">
+            <summary>
+            Highest non-zero <c>BGMFadeType.FadeInStartTime</c> (seconds) across every entry
+            in <see cref="P:Sharlayan.Models.ReadResults.GameStateResult.BgmScenes"/>. This is the *delay* between a scene's PlayingBgmId
+            becoming non-zero and audio actually starting its volume ramp; the longest such
+            delay among all scenes is what determines when the user will hear the new track.
+            Zero scenes don't contribute — a single scene with a 0.5s start delay wins over
+            many scenes at 0. 0 if all scenes are 0 or sqpack/Lumina isn't available.
+            </summary>
+        </member>
+        <member name="P:Sharlayan.Models.ReadResults.GameStateResult.BgmResume">
+            <summary>
+            Highest non-zero <c>BGMFadeType.ResumeFadeInTime</c> (seconds) across every
+            entry in <see cref="P:Sharlayan.Models.ReadResults.GameStateResult.BgmScenes"/>. Used by the game when resuming a previously
+            paused track rather than starting fresh. Zero entries are skipped. 0 if all
+            scenes are 0 or sqpack/Lumina isn't available.
+            </summary>
+        </member>
+        <member name="P:Sharlayan.Models.ReadResults.GameStateResult.AnySoundLoading">
+            <summary>
+            True if any active SoundData entry has IsLoadingSoundResource set. Walked from
+            SoundManager.ActiveSoundDataListHead following ISoundData.Next. This is a coarse
+            "audio engine is loading something right now" signal — during a BGM transition
+            (zone change, scene swap) the new BGM SoundData briefly raises this flag, so it
+            works as a proxy for "BGM is transitioning". Returns false during steady-state
+            playback. Set to false if SoundManager isn't resolved.
+            </summary>
+        </member>
+        <member name="P:Sharlayan.Models.ReadResults.GameStateResult.IsBgmAudible">
+            <summary>
+            True when audible audio energy is present on the *music* bus specifically
+            (sourced from <c>SoundManager._FFTBlue1</c> — FCS labels Blue as the Music bus,
+            distinct from Red=System and Green=SE/Voice/Instruments).
+            <para>
+            <b>Post-master-volume</b> — this is the speaker output, so muting BGM in-game or
+            dropping the slider to 0 will keep this false even when music is playing in the
+            audio engine. For a pre-fader signal that ignores user volume settings, consume
+            <see cref="P:Sharlayan.Models.ReadResults.GameStateResult.BgmScenes"/> directly (a non-zero <c>PlayingBgmId</c> on any scene means
+            the audio engine has selected a track regardless of user volume).
+            </para>
+            Set to false if SoundManager isn't resolved.
+            </summary>
         </member>
         <member name="M:Sharlayan.Reader.GetZoneName(System.UInt32,System.String)">
             <summary>

--- a/Sharlayan/Signatures.cs
+++ b/Sharlayan/Signatures.cs
@@ -51,6 +51,8 @@ namespace Sharlayan {
 
         public const string RECAST_KEY = "RECAST";
 
+        public const string SOUNDMANAGER_KEY = "SOUNDMANAGER";
+
         public const string TARGET_KEY = "TARGET";
 
         public const string WEATHER_KEY = "WEATHER";

--- a/Sharlayan/version.props
+++ b/Sharlayan/version.props
@@ -5,7 +5,7 @@
          Patch: incremented by Claude/AI on each substantive code change to Sharlayan. -->
     <VersionMajor>9</VersionMajor>
     <VersionMinor>0</VersionMinor>
-    <VersionPatch>9</VersionPatch>
+    <VersionPatch>18</VersionPatch>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Derived version strings — do not edit these directly. -->


### PR DESCRIPTION
## Summary

Adds visibility into every BGM scene layer plus the Lumina-resolved fade presets that govern how each scene's audio fades in/out. Useful for downstream consumers (Chromatics) needing to detect when music actually becomes audible vs when the engine has merely selected a track.

### New types in `Sharlayan.Models.ReadResults`
- `BgmSceneType` enum (Event=0, Battle=1, ..., Territory=11) — index into `BgmScenes`.
- `BgmSceneInfo` — one per `BGMSystem.Scenes` slot with `BgmId` (intended), `PlayingBgmId` (actual), `PreviousBgmId`, `IsPlaying` (computed, ignores silence sentinel id=1), `PlayingBgmFile` (Lumina), `PlayState`, `EnableCustomFade`, `FadeOutTime`/`FadeInTime` (custom override, ms), and Lumina presets `PresetFadeOutTime` / `PresetFadeInTime` / `PresetFadeInStartTime` / `PresetResumeFadeInTime` (seconds).

### New top-level fields on `GameStateResult`
- `BgmScenes` — `IReadOnlyList<BgmSceneInfo>`, all 12 entries.
- `CurrentBgmTargetId` — `Scene.BgmId` of the winning scene (differs from `CurrentBgmId` mid-BGMSwitch).
- `BgmFadeIn` / `BgmResume` — highest non-zero preset across all scenes; `BgmFadeIn` is the delay before audio starts on rising edge.
- `IsBgmAudible` — `SoundManager._FFTBlue1` music-bus FFT (post-master-volume; muting BGM keeps it false).
- `AnySoundLoading` — OR over active SoundData `IsLoadingSoundResource` flags.
- `IsTeleporting` — `Conditions.BetweenAreas` / `BetweenAreas51`.

### Infrastructure
- New `SOUNDMANAGER` scanner key, derived via `[StaticAddress]` like every other key.
- `LuminaGameDataCache` — process-wide shared `Lumina.GameData` with tuned `LuminaOptions` (`CacheFileResources=false`, no checksum panic, multi-threaded load). Used by both `Reader.GameState` and `LuminaXivDatabaseProvider`.
- Reader caches the EN Weather / BGM / BGMFadeType sheet refs; per-frame `GetSheet<T>()` becomes a field read.
- Integrity tests for `SoundManager` singleton resolution and the private `_FFTBlue1` field.

### Harness
- Rewritten to render only the `[3c.2]` GameState block (others commented out, easy to re-enable). The live-refresh loop now redraws the gamestate every 500 ms, listing all 12 scenes with their custom + preset fade times so transitions can be observed in-game.

## Test plan

- [x] `dotnet test` — 136/136 passing
- [x] Debug build + deploy to Chromatics Build Dependencies
- [ ] Live verify in-game: scene array populates, transitions show `IsPlaying`, preset fade times match observed audible delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)