### PR TITLE
chore: FFXIV Patch 5.5 "Trail to the Heavens" + LuminaLookup + status-resolver fixes + StatusNameEnglish

### DIFF
--- a/DEPENDENCY.md
+++ b/DEPENDENCY.md
@@ -42,7 +42,7 @@ Each of these has a `public static partial Instance()` method decorated with `[S
 | File | Field | Used offset | Why |
 |---|---|---|---|
 | `FFXIV/Client/System/Framework/Framework.cs` | `Framework.UIModule` | `0x2B68` | Deref hop to `UIModule*` |
-| `FFXIV/Client/UI/UIModule.cs` | `UIModule.RaptureLogModule` | `0x19E0` | Trailing offset to land on RaptureLogModule |
+| `FFXIV/Client/UI/UIModule.cs` | `UIModule.RaptureLogModule` | `0x1AC0` | Trailing offset to land on RaptureLogModule (was `0x19E0`; bumped by FCS "Update UIModule") |
 | `FFXIV/Client/UI/Misc/RaptureLogModule.cs` | (exposed via `FFXIV/Component/Log/LogModule.cs`) | n/a | RaptureLogModule contains a `LogModule` instance Sharlayan parses via `ChatLogPointersMapper` |
 | `FFXIV/Component/Log/LogModule.cs` | `LogModule.LogMessageIndex` / `LogMessageData` | `Marshal.OffsetOf` | Two `StdVector<T>` offsets (First/Last/End) for the ring buffer |
 
@@ -51,7 +51,7 @@ Each of these has a `public static partial Instance()` method decorated with `[S
 | File | Field | Used offset |
 |---|---|---|
 | `FFXIV/Client/System/Framework/Framework.cs` | `Framework.UIModule` | `0x2B68` |
-| `FFXIV/Client/UI/UIModule.cs` | `UIModule.RaptureHotbarModule` | `0x57B80` |
+| `FFXIV/Client/UI/UIModule.cs` | `UIModule.RaptureHotbarModule` | `0x57C60` (was `0x57B80`; bumped by FCS "Update UIModule") |
 | `FFXIV/Client/UI/Misc/RaptureHotbarModule.cs` | `_hotbars` private array | `0xA0` (additive) |
 | `FFXIV/Client/UI/Misc/RaptureHotbarModule.HotbarSlot.cs` | `HotbarSlot.PopUpHelp` / `.CommandId` / `_popUpKeybindHint` | `Marshal.OffsetOf` / `FieldOffsetReader` |
 

--- a/Sharlayan.Harness/Program.cs
+++ b/Sharlayan.Harness/Program.cs
@@ -84,7 +84,7 @@ internal static class Program {
         Log(string.Empty);
 
         // [2] FFXIVClientStructs struct sizes — commented out; re-enable for FCS-bump diagnostics.
-        /*
+        
         Log("[2] FFXIVCLIENTSTRUCTS STRUCT SIZES (runtime Marshal.SizeOf)");
         DumpSize<Character>(Log, 0x2370);
         DumpSize<CharacterData>(Log, 0x50);
@@ -104,9 +104,9 @@ internal static class Program {
         DumpSize<RaptureHotbarModule.HotbarSlot>(Log, 0xE8);
         DumpSize<PlayerState>(Log, 0x908);
         DumpSize<LogModule>(Log, 0x80);
-        DumpSize<Vector3>(Log, 0x0C);
+        DumpSize<Vector3>(Log, 0x10);
         Log(string.Empty);
-        */
+        
 
         // [3] FFXIVClientStructsDirect scanner + reader ----------------------
         SharlayanConfiguration directConfig = new() {
@@ -128,16 +128,16 @@ internal static class Program {
             int directCount = directHandler.Scanner.Locations.Count;
             Log($"  {directCount} location(s) resolved");
             // Address listing — commented out; re-enable to verify all scanner keys resolved.
-            /*
+            
             foreach (string key in directHandler.Scanner.Locations.Keys.OrderBy(k => k)) {
                 IntPtr addr = directHandler.Scanner.Locations[key];
                 Log($"    ✓ {key,-20} 0x{addr.ToInt64():X12}");
             }
-            */
+            
 
             // [3b] End-to-end Reader check — commented out; re-enable to validate
             // CurrentPlayer / Actors / Party reads against the in-game UI.
-            /*
+            
             Log(string.Empty);
             Log("  [3b] READER OUTPUT");
             try {
@@ -176,14 +176,14 @@ internal static class Program {
             catch (Exception ex) {
                 Log($"    ✗ Party: {ex.GetType().Name}: {ex.Message}");
             }
-            */
+            
 
             // [3c] + [3c.2] — extracted so the live-refresh loop below can call the
             // same renderer and keep its output pointing at fresh in-game values.
             RenderEyeCheckAndGameState(directHandler, Log);
 
             // [3d] Chat log — commented out; re-enable to validate Framework→UIModule→RaptureLogModule chain.
-            /*
+            
             Log(string.Empty);
             Log("  [3d] CHAT LOG");
             try {
@@ -210,54 +210,86 @@ internal static class Program {
             catch (Exception ex) {
                 Log($"    ✗ Chat read: {ex.GetType().Name}: {ex.Message}");
             }
-            */
+            
         }
         catch (Exception ex) {
             Log($"  ✗ Direct scanner failed: {ex.GetType().Name}: {ex.Message}");
         }
         Log(string.Empty);
 
-        // [4] Lumina xivdatabase smoke test — commented out; re-enable to validate sqpack access.
-        /*
+        // [4] Lumina xivdatabase smoke test — probes every sheet the rest of the codebase
+        // depends on (xivdatabase + Reader.GameState) and reports each one independently.
+        // A MismatchedColumnHashException on a single sheet is normal during the gap
+        // between an FFXIV patch and a matching Lumina.Excel package release; this block
+        // makes that gap explicit so we know exactly which sheet to wait on.
+
         Log("[4] LUMINA XIVDATABASE VALIDATION");
+        global::Lumina.GameData? lumina = null;
         try {
             string sqpack = Path.Combine(Path.GetDirectoryName(game.MainModule!.FileName)!, "sqpack");
             Log($"  sqpack path : {sqpack}");
             Log($"  exists      : {Directory.Exists(sqpack)}");
+            lumina = new global::Lumina.GameData(sqpack);
+        }
+        catch (Exception ex) {
+            Log($"  ✗ GameData open failed: {ex.GetType().Name}: {ex.Message}");
+        }
 
-            var lumina = new global::Lumina.GameData(sqpack);
-            var action = lumina.Excel.GetSheet<global::Lumina.Excel.Sheets.Action>();
-            var status = lumina.Excel.GetSheet<global::Lumina.Excel.Sheets.Status>();
-            var territory = lumina.Excel.GetSheet<global::Lumina.Excel.Sheets.TerritoryType>();
-            var place = lumina.Excel.GetSheet<global::Lumina.Excel.Sheets.PlaceName>();
-
-            Log($"  ✓ Action sheet     : {action.Count} rows");
-            Log($"  ✓ Status sheet     : {status.Count} rows");
-            Log($"  ✓ TerritoryType    : {territory.Count} rows");
-            Log($"  ✓ PlaceName        : {place.Count} rows");
-
-            if (action.HasRow(7)) {
-                Log($"    Action[7].Name     : \"{action.GetRow(7).Name.ExtractText()}\"");
+        if (lumina != null) {
+            // Probe each typed sheet on its own. A MismatchedColumnHashException tells us
+            // which sheet's column layout has shifted in the current game patch but not
+            // yet in the Lumina.Excel package — that's the one blocking name lookups.
+            void ProbeSheet<T>(string label) where T : struct, global::Lumina.Excel.IExcelRow<T> {
+                try {
+                    var sheet = lumina.Excel.GetSheet<T>();
+                    Log($"  ✓ {label,-15} : {sheet.Count} rows");
+                }
+                catch (Exception ex) {
+                    string msg = ex.Message.Replace("\n", " ").Trim();
+                    if (msg.Length > 110) msg = msg.Substring(0, 107) + "…";
+                    Log($"  ✗ {label,-15} : {ex.GetType().Name}: {msg}");
+                }
             }
+
+            // Sheets used by LuminaXivDatabaseProvider (xivdatabase actions/statuses/zones).
+            ProbeSheet<global::Lumina.Excel.Sheets.Action>("Action");
+            ProbeSheet<global::Lumina.Excel.Sheets.Status>("Status");
+            ProbeSheet<global::Lumina.Excel.Sheets.TerritoryType>("TerritoryType");
+            ProbeSheet<global::Lumina.Excel.Sheets.PlaceName>("PlaceName");
+            // Sheets used by Reader.GameState (live weather + BGM + fade presets).
+            ProbeSheet<global::Lumina.Excel.Sheets.Weather>("Weather");
+            ProbeSheet<global::Lumina.Excel.Sheets.BGM>("BGM");
+            ProbeSheet<global::Lumina.Excel.Sheets.BGMFade>("BGMFade");
+            ProbeSheet<global::Lumina.Excel.Sheets.BGMFadeType>("BGMFadeType");
+
+            // Sample lookups — best-effort, only run when the relevant sheets resolved.
+            try {
+                var action = lumina.Excel.GetSheet<global::Lumina.Excel.Sheets.Action>();
+                if (action.HasRow(7)) {
+                    Log($"    Action[7].Name     : \"{action.GetRow(7).Name.ExtractText()}\"");
+                }
+            }
+            catch { }
             if (directHandler != null) {
                 try {
                     var cp = directHandler.Reader.GetCurrentPlayer();
                     uint tid = cp?.Entity?.MapTerritory ?? 0;
-                    if (tid != 0 && territory.HasRow(tid)) {
-                        uint pnId = territory.GetRow(tid).PlaceName.RowId;
-                        if (place.HasRow(pnId)) {
-                            Log($"    Current territory[{tid}].PlaceName = \"{place.GetRow(pnId).Name.ExtractText()}\"");
+                    if (tid != 0) {
+                        var territory = lumina.Excel.GetSheet<global::Lumina.Excel.Sheets.TerritoryType>();
+                        var place     = lumina.Excel.GetSheet<global::Lumina.Excel.Sheets.PlaceName>();
+                        if (territory.HasRow(tid)) {
+                            uint pnId = territory.GetRow(tid).PlaceName.RowId;
+                            if (place.HasRow(pnId)) {
+                                Log($"    Current territory[{tid}].PlaceName = \"{place.GetRow(pnId).Name.ExtractText()}\"");
+                            }
                         }
                     }
                 }
-                catch { }
+                catch { /* one of the sheets above failed to resolve; already logged */ }
             }
         }
-        catch (Exception ex) {
-            Log($"  ✗ Lumina failed: {ex.GetType().Name}: {ex.Message}");
-        }
         Log(string.Empty);
-        */
+
 
         Log("====== END HARNESS ======");
 
@@ -327,7 +359,7 @@ internal static class Program {
     private static void RenderEyeCheckAndGameState(MemoryHandler handler, Action<string> log) {
         // [3c] Eye-check values — commented out; re-enable to surface LocalPlayer / actors /
         // target / hotbar / job-resource fields for manual UI verification.
-        /*
+        
         try {
             var dp = handler.Reader.GetCurrentPlayer()?.Entity;
             if (dp != null) {
@@ -452,7 +484,6 @@ internal static class Program {
         catch (Exception ex) {
             log($"    ✗ EyeCheck: {ex.GetType().Name}: {ex.Message}");
         }
-        */
 
         // [3c.2] GameState — validates GAMEMAIN / CONDITIONS / CONTENTSFINDER / WEATHER /
         // BGMSYSTEM signatures + Lumina name lookups in one shot.

--- a/Sharlayan.Harness/Program.cs
+++ b/Sharlayan.Harness/Program.cs
@@ -513,6 +513,40 @@ internal static class Program {
             log($"    ✗ EyeCheck: {ex.GetType().Name}: {ex.Message}");
         }
 
+        // [3c.1] STATUS LOCALIZATION — prints the local player's currently-active status
+        // entries showing both StatusName (localized per Configuration.GameLanguage) and the
+        // new StatusNameEnglish (always English regardless of language). ActorItem.StatusItems
+        // can hold stale slots (expired Duration=0 entries, or slots whose StatusID is out of
+        // the XIVDatabase range and resolves to "???"); we skip both so the display only
+        // shows what's actually applied right now.
+        try {
+            var dpStatus = handler.Reader.GetCurrentPlayer()?.Entity;
+            if (dpStatus != null) {
+                log(string.Empty);
+                log($"  [3c.1] LOCAL PLAYER STATUSES (GameLanguage={handler.Configuration.GameLanguage})");
+                int shown = 0;
+                if (dpStatus.StatusItems != null) {
+                    foreach (var s in dpStatus.StatusItems) {
+                        if (!s.IsValid()) continue;
+                        // Hard filters: expired slots (Duration <= 0) and IDs the XIVDatabase
+                        // didn't resolve (StatusNameEnglish == "???") are residual / garbage.
+                        if (s.Duration <= 0f) continue;
+                        if (string.IsNullOrEmpty(s.StatusNameEnglish) || s.StatusNameEnglish == Sharlayan.Constants.UNKNOWN_LOCALIZED_NAME) continue;
+                        if (shown++ >= 6) break;
+                        string en = s.StatusNameEnglish;
+                        string loc = s.StatusName ?? "(null)";
+                        log($"    [{s.StatusID,4}] StatusName=\"{loc}\"  StatusNameEnglish=\"{en}\"  Stacks={s.Stacks}  Duration={s.Duration:F1}s");
+                    }
+                }
+                if (shown == 0) {
+                    log("    (no active statuses on local player)");
+                }
+            }
+        }
+        catch (Exception ex) {
+            log($"    ✗ StatusLocalization: {ex.GetType().Name}: {ex.Message}");
+        }
+
         // [3c.2] GameState — validates GAMEMAIN / CONDITIONS / CONTENTSFINDER / WEATHER /
         // BGMSYSTEM signatures + Lumina name lookups in one shot.
         try {

--- a/Sharlayan.Harness/Program.cs
+++ b/Sharlayan.Harness/Program.cs
@@ -102,7 +102,7 @@ internal static class Program {
         DumpSize<HaterInfo>(Log, 0x48);
         DumpSize<RecastDetail>(Log, 0x14);
         DumpSize<RaptureHotbarModule.HotbarSlot>(Log, 0xE8);
-        DumpSize<PlayerState>(Log, 0x908);
+        DumpSize<PlayerState>(Log, 0x920);
         DumpSize<LogModule>(Log, 0x80);
         DumpSize<Vector3>(Log, 0x10);
         Log(string.Empty);
@@ -290,6 +290,34 @@ internal static class Program {
         }
         Log(string.Empty);
 
+        // [5] LuminaLookup name → row-id smoke test. Exercises every public helper with a
+        // well-known fixture and prints the resolved id. Each helper is called twice — once
+        // with the English name and once with another language — to verify the multi-language
+        // union builds correctly. Misses (null) print "✗ <not found>" so we can spot which
+        // sheet's hash mismatch is breaking lookups during a patch-day window.
+        Log("[5] LUMINA LOOKUP (name → row id)");
+        if (directHandler != null) {
+            SharlayanConfiguration cfg = directConfig;
+            void Probe(string label, uint? id) {
+                Log(id.HasValue ? $"  ✓ {label,-50} → {id.Value}" : $"  ✗ {label,-50} → (not found)");
+            }
+            Probe("Weather                 \"Moon Dust\"",          LuminaLookup.WeatherIdFromName(cfg, "Moon Dust"));
+            Probe("Weather (JP)            \"快晴\"",                LuminaLookup.WeatherIdFromName(cfg, "快晴")); // Clear Skies
+            Probe("Action                  \"Refulgent Arrow\"",    LuminaLookup.ActionIdFromName(cfg, "Refulgent Arrow"));
+            Probe("Action (JP)             \"リフルジェントアロー\"", LuminaLookup.ActionIdFromName(cfg, "リフルジェントアロー"));
+            Probe("Status                  \"Sleep\"",              LuminaLookup.StatusIdFromName(cfg, "Sleep"));
+            Probe("PlaceName               \"Limsa Lominsa Lower Decks\"", LuminaLookup.PlaceNameIdFromName(cfg, "Limsa Lominsa Lower Decks"));
+            Probe("ContentFinderCondition  \"The Aery\"",           LuminaLookup.ContentFinderConditionIdFromName(cfg, "The Aery"));
+            Probe("Item                    \"Potion\"",             LuminaLookup.ItemIdFromName(cfg, "Potion"));
+            Probe("BNpcName                \"striking dummy\"",     LuminaLookup.BNpcNameIdFromName(cfg, "striking dummy"));
+            Probe("ENpcResident            \"Hancock\"",            LuminaLookup.ENpcResidentIdFromName(cfg, "Hancock"));
+            Probe("Mount                   \"Company Chocobo\"",    LuminaLookup.MountIdFromName(cfg, "Company Chocobo"));
+            Probe("Companion               \"Wind-up Cursor\"",     LuminaLookup.CompanionIdFromName(cfg, "Wind-up Cursor"));
+        }
+        else {
+            Log("  ✗ directHandler is null — skipping (scanner setup must succeed first)");
+        }
+        Log(string.Empty);
 
         Log("====== END HARNESS ======");
 

--- a/Sharlayan.Tests/LocalizationHelperTests.cs
+++ b/Sharlayan.Tests/LocalizationHelperTests.cs
@@ -1,0 +1,109 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="LocalizationHelperTests.cs" company="SyndicatedLife">
+//   Copyright© 2007 - 2022 Ryan Wilson <syndicated.life@gmail.com> (https://syndicated.life/)
+//   Licensed under the MIT license. See LICENSE.md in the solution root for full license information.
+// </copyright>
+// <summary>
+//   Covers Sharlayan.Utilities.LocalizationHelper.SelectLocalized — the pure
+//   language-selection helper that ActorItemResolver / PartyMemberResolver use to populate
+//   the localised StatusName and English-pinned StatusNameEnglish fields. Direct unit tests
+//   here let us prove the cross-language behaviour without spinning up a MemoryHandler /
+//   live process.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Sharlayan.Tests {
+    using Sharlayan.Core;
+    using Sharlayan.Enums;
+    using Sharlayan.Models;
+    using Sharlayan.Utilities;
+
+    using Xunit;
+
+    public class LocalizationHelperTests {
+        // Fixture mirroring the FFXIV "Iron Will" tank stance row across all six locales
+        // Sharlayan tracks. Used to verify the helper picks the right slot per language and
+        // that the English-pinned counterpart is unaffected by the language switch.
+        private static Localization IronWillNames() => new Localization {
+            English  = "Iron Will",
+            Japanese = "アイアンウィル",
+            German   = "Eisenwille",
+            French   = "Volonté de fer",
+            Chinese  = "铁壁",
+            Korean   = "굳건한 의지",
+        };
+
+        [Theory]
+        [InlineData(GameLanguage.English,  "Iron Will")]
+        [InlineData(GameLanguage.Japanese, "アイアンウィル")]
+        [InlineData(GameLanguage.German,   "Eisenwille")]
+        [InlineData(GameLanguage.French,   "Volonté de fer")]
+        [InlineData(GameLanguage.Chinese,  "铁壁")]
+        [InlineData(GameLanguage.Korean,   "굳건한 의지")]
+        public void SelectLocalized_ReturnsRequestedLanguage(GameLanguage language, string expected) {
+            Assert.Equal(expected, LocalizationHelper.SelectLocalized(IronWillNames(), language));
+        }
+
+        [Fact]
+        public void SelectLocalized_FallsBackToEnglish_WhenLanguageSlotIsNull() {
+            Localization names = IronWillNames();
+            names.Japanese = null;
+            // GameLanguage.Japanese requested but JP slot empty → English fallback.
+            Assert.Equal("Iron Will", LocalizationHelper.SelectLocalized(names, GameLanguage.Japanese));
+        }
+
+        [Fact]
+        public void SelectLocalized_NullNames_ReturnsNull() {
+            Assert.Null(LocalizationHelper.SelectLocalized(null, GameLanguage.English));
+            Assert.Null(LocalizationHelper.SelectLocalized(null, GameLanguage.Japanese));
+        }
+
+        // ------------------------------------------------------------------------------
+        // StatusItem schema check — both StatusName and StatusNameEnglish must be public
+        // settable strings (used by both resolvers + downstream consumers). Pin the surface
+        // so a future rename / removal breaks loudly.
+        // ------------------------------------------------------------------------------
+
+        [Fact]
+        public void StatusItem_StatusName_IsPublicSettableString() {
+            var prop = typeof(StatusItem).GetProperty(nameof(StatusItem.StatusName));
+            Assert.NotNull(prop);
+            Assert.Equal(typeof(string), prop!.PropertyType);
+            Assert.True(prop.CanRead);
+            Assert.True(prop.CanWrite);
+        }
+
+        [Fact]
+        public void StatusItem_StatusNameEnglish_IsPublicSettableString() {
+            var prop = typeof(StatusItem).GetProperty(nameof(StatusItem.StatusNameEnglish));
+            Assert.NotNull(prop);
+            Assert.Equal(typeof(string), prop!.PropertyType);
+            Assert.True(prop.CanRead);
+            Assert.True(prop.CanWrite);
+        }
+
+        // ------------------------------------------------------------------------------
+        // Resolver-style end-to-end: simulates the resolver's three-line block (localised
+        // + English-pinned) for every non-default language. This is exactly what
+        // ActorItemResolver and PartyMemberResolver do when populating each statusEntry —
+        // running it standalone proves the StatusNameEnglish field always returns the
+        // English literal regardless of the configured language.
+        // ------------------------------------------------------------------------------
+
+        [Theory]
+        [InlineData(GameLanguage.Japanese, "アイアンウィル")]
+        [InlineData(GameLanguage.German,   "Eisenwille")]
+        [InlineData(GameLanguage.French,   "Volonté de fer")]
+        [InlineData(GameLanguage.Chinese,  "铁壁")]
+        [InlineData(GameLanguage.Korean,   "굳건한 의지")]
+        public void ResolverPattern_StatusNameEnglish_IsAlwaysEnglish_RegardlessOfGameLanguage(GameLanguage language, string expectedLocalised) {
+            Localization names = IronWillNames();
+            StatusItem statusEntry = new StatusItem {
+                StatusName        = LocalizationHelper.SelectLocalized(names, language),
+                StatusNameEnglish = names.English,
+            };
+            Assert.Equal(expectedLocalised, statusEntry.StatusName);
+            Assert.Equal("Iron Will", statusEntry.StatusNameEnglish);
+        }
+    }
+}

--- a/Sharlayan.Tests/LuminaLookupTests.cs
+++ b/Sharlayan.Tests/LuminaLookupTests.cs
@@ -1,0 +1,155 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="LuminaLookupTests.cs" company="SyndicatedLife">
+//   Copyright© 2007 - 2022 Ryan Wilson <syndicated.life@gmail.com> (https://syndicated.life/)
+//   Licensed under the MIT license. See LICENSE.md in the solution root for full license information.
+// </copyright>
+// <summary>
+//   Structural tests for Sharlayan.LuminaLookup. CI doesn't have an FFXIV sqpack to read,
+//   so the assertions here are limited to what we can verify without one:
+//   - Each helper exists with the expected public static signature.
+//   - Each helper degrades gracefully (null result) when sqpack can't be resolved.
+//   - The generic FindRowId entry point handles null/empty inputs cleanly.
+//   - ClearCache resets the cache without throwing.
+//   The harness exercises the live-sqpack path with known fixtures.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Sharlayan.Tests {
+    using System;
+    using System.Reflection;
+
+    using Sharlayan;
+
+    using Xunit;
+
+    public class LuminaLookupTests {
+        // A configuration with no GameInstallPath and no ProcessModel — LuminaGameDataCache
+        // will fail to resolve sqpack and return null, exercising the graceful-degradation
+        // path through every public helper.
+        private static SharlayanConfiguration ConfigWithoutSqpack() => new SharlayanConfiguration {
+            GameInstallPath = null,
+            ProcessModel = null,
+        };
+
+        // ------------------------------------------------------------------------------
+        // Per-helper graceful-degradation: null sqpack → null result for every method.
+        // ------------------------------------------------------------------------------
+
+        [Fact]
+        public void WeatherIdFromName_NoSqpack_ReturnsNull() {
+            Assert.Null(LuminaLookup.WeatherIdFromName(ConfigWithoutSqpack(), "Moon Dust"));
+        }
+
+        [Fact]
+        public void ActionIdFromName_NoSqpack_ReturnsNull() {
+            Assert.Null(LuminaLookup.ActionIdFromName(ConfigWithoutSqpack(), "Refulgent Arrow"));
+        }
+
+        [Fact]
+        public void StatusIdFromName_NoSqpack_ReturnsNull() {
+            Assert.Null(LuminaLookup.StatusIdFromName(ConfigWithoutSqpack(), "Sleep"));
+        }
+
+        [Fact]
+        public void PlaceNameIdFromName_NoSqpack_ReturnsNull() {
+            Assert.Null(LuminaLookup.PlaceNameIdFromName(ConfigWithoutSqpack(), "Limsa Lominsa Lower Decks"));
+        }
+
+        [Fact]
+        public void ContentFinderConditionIdFromName_NoSqpack_ReturnsNull() {
+            Assert.Null(LuminaLookup.ContentFinderConditionIdFromName(ConfigWithoutSqpack(), "The Aery"));
+        }
+
+        [Fact]
+        public void ItemIdFromName_NoSqpack_ReturnsNull() {
+            Assert.Null(LuminaLookup.ItemIdFromName(ConfigWithoutSqpack(), "Potion"));
+        }
+
+        [Fact]
+        public void BNpcNameIdFromName_NoSqpack_ReturnsNull() {
+            Assert.Null(LuminaLookup.BNpcNameIdFromName(ConfigWithoutSqpack(), "striking dummy"));
+        }
+
+        [Fact]
+        public void ENpcResidentIdFromName_NoSqpack_ReturnsNull() {
+            Assert.Null(LuminaLookup.ENpcResidentIdFromName(ConfigWithoutSqpack(), "Hancock"));
+        }
+
+        [Fact]
+        public void MountIdFromName_NoSqpack_ReturnsNull() {
+            Assert.Null(LuminaLookup.MountIdFromName(ConfigWithoutSqpack(), "Company Chocobo"));
+        }
+
+        [Fact]
+        public void CompanionIdFromName_NoSqpack_ReturnsNull() {
+            Assert.Null(LuminaLookup.CompanionIdFromName(ConfigWithoutSqpack(), "Wind-up Cursor"));
+        }
+
+        // ------------------------------------------------------------------------------
+        // Input-validation: empty / null / null-config / null-selector all return null
+        // without throwing.
+        // ------------------------------------------------------------------------------
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void WeatherIdFromName_NullOrEmpty_ReturnsNull(string? name) {
+            Assert.Null(LuminaLookup.WeatherIdFromName(ConfigWithoutSqpack(), name!));
+        }
+
+        [Fact]
+        public void FindRowId_NullConfiguration_ReturnsNull() {
+            Assert.Null(LuminaLookup.FindRowId<Lumina.Excel.Sheets.Weather>(null!, "Moon Dust", r => r.Name.ExtractText()));
+        }
+
+        [Fact]
+        public void FindRowId_NullNameSelector_ReturnsNull() {
+            Assert.Null(LuminaLookup.FindRowId<Lumina.Excel.Sheets.Weather>(ConfigWithoutSqpack(), "Moon Dust", null!));
+        }
+
+        // ------------------------------------------------------------------------------
+        // Cache cycle — ClearCache must not throw whether the cache is empty or populated.
+        // ------------------------------------------------------------------------------
+
+        [Fact]
+        public void ClearCache_DoesNotThrow_WhenEmpty() {
+            // No prior calls. Just verify the method is callable.
+            LuminaLookup.ClearCache();
+        }
+
+        [Fact]
+        public void ClearCache_DoesNotThrow_AfterUse() {
+            // Prime an entry then clear; should be a no-op equivalent.
+            _ = LuminaLookup.WeatherIdFromName(ConfigWithoutSqpack(), "Moon Dust");
+            LuminaLookup.ClearCache();
+        }
+
+        // ------------------------------------------------------------------------------
+        // Surface contract — each public helper exists with the expected signature.
+        // Catches accidental rename / signature drift that the call-site tests above
+        // wouldn't (since those compile against the public surface anyway).
+        // ------------------------------------------------------------------------------
+
+        [Theory]
+        [InlineData(nameof(LuminaLookup.WeatherIdFromName))]
+        [InlineData(nameof(LuminaLookup.ActionIdFromName))]
+        [InlineData(nameof(LuminaLookup.StatusIdFromName))]
+        [InlineData(nameof(LuminaLookup.PlaceNameIdFromName))]
+        [InlineData(nameof(LuminaLookup.ContentFinderConditionIdFromName))]
+        [InlineData(nameof(LuminaLookup.ItemIdFromName))]
+        [InlineData(nameof(LuminaLookup.BNpcNameIdFromName))]
+        [InlineData(nameof(LuminaLookup.ENpcResidentIdFromName))]
+        [InlineData(nameof(LuminaLookup.MountIdFromName))]
+        [InlineData(nameof(LuminaLookup.CompanionIdFromName))]
+        public void Helper_HasExpectedSignature(string methodName) {
+            MethodInfo? method = typeof(LuminaLookup).GetMethod(
+                methodName,
+                BindingFlags.Public | BindingFlags.Static,
+                binder: null,
+                types: new[] { typeof(SharlayanConfiguration), typeof(string) },
+                modifiers: null);
+            Assert.NotNull(method);
+            Assert.Equal(typeof(uint?), method!.ReturnType);
+        }
+    }
+}

--- a/Sharlayan.Tests/Resources/Mappers/PartyMemberMapperTests.cs
+++ b/Sharlayan.Tests/Resources/Mappers/PartyMemberMapperTests.cs
@@ -62,18 +62,23 @@ namespace Sharlayan.Tests.Resources.Mappers {
             Assert.True(partyMember.Y > 0, nameof(PartyMember.Y));
             Assert.True(partyMember.Z > 0, nameof(PartyMember.Z));
             Assert.True(partyMember.SourceSize > 0, nameof(PartyMember.SourceSize));
-            // DefaultStatusEffectOffset is explicitly 0 (StatusManager is at offset 0),
-            // so it is a "mapped but zero" field. Verified separately below.
+            // DefaultStatusEffectOffset = StatusManager_offset + StatusManager._status_offset
+            // = 0 + 0x8 = 8 (StatusManager sits at +0 in PartyMember; the _status array
+            // begins 8 bytes into StatusManager, after the Owner pointer).
+            Assert.True(partyMember.DefaultStatusEffectOffset > 0, nameof(PartyMember.DefaultStatusEffectOffset));
         }
 
         [Fact]
-        public void Build_DefaultStatusEffectOffset_IsStatusManagerOffset() {
-            // StatusManager sits at native offset 0 inside PartyMember, so this field
-            // legitimately maps to zero. Pin that so a regression to "DefaultStatusEffectOffset
-            // should obviously be non-zero" doesn't accidentally bust the mapping.
+        public void Build_DefaultStatusEffectOffset_PointsAtFirstStatusSlot() {
+            // Must point at StatusManager._status[0] (the first Status entry), NOT the
+            // StatusManager struct base — otherwise the resolver's BlockCopy reads the
+            // 8-byte Owner pointer as part of the first slot, shifting every status by
+            // -8 bytes and producing garbage StatusIDs / Stacks. Pin the math so a
+            // regression to plain "StatusManager offset" gets caught here.
             PartyMember partyMember = PartyMemberMapper.Build();
-            Assert.Equal((int)Marshal.OffsetOf<NativePartyMember>(nameof(NativePartyMember.StatusManager)), partyMember.DefaultStatusEffectOffset);
-            Assert.Equal(0, partyMember.DefaultStatusEffectOffset);
+            int statusManagerOff = (int)Marshal.OffsetOf<NativePartyMember>(nameof(NativePartyMember.StatusManager));
+            int statusArrayOff   = FieldOffsetReader.OffsetOf<FFXIVClientStructs.FFXIV.Client.Game.StatusManager>("_status");
+            Assert.Equal(statusManagerOff + statusArrayOff, partyMember.DefaultStatusEffectOffset);
         }
     }
 }

--- a/Sharlayan.Tests/Resources/Providers/FCSDependencyIntegrityTests.cs
+++ b/Sharlayan.Tests/Resources/Providers/FCSDependencyIntegrityTests.cs
@@ -131,6 +131,7 @@ namespace Sharlayan.Tests.Resources.Providers {
         }
 
 
+
         [Fact]
         public void PrivateFieldOffset_PlayerState_classJobLevels_Resolves() {
             AssertPrivateFieldExists<PlayerState>("_classJobLevels");
@@ -197,13 +198,18 @@ namespace Sharlayan.Tests.Resources.Providers {
         }
 
         [Fact]
-        public void HardCodedChainOffset_UIModule_RaptureLogModule_Is_0x19E0() {
-            Assert.Equal(0x19E0, FieldOffsetAttributeValue(typeof(UIModule), "RaptureLogModule"));
+        public void HardCodedChainOffset_UIModule_RaptureLogModule_Is_0x1AC0() {
+            // Bumped from 0x19E0 → 0x1AC0 by FCS commit "Update UIModule" (036e201a2 base).
+            // Runtime reads via FieldOffsetReader so CHATLOG_KEY auto-tracks the move; this
+            // test merely pins the known-good value for the next FCS bump diff.
+            Assert.Equal(0x1AC0, FieldOffsetAttributeValue(typeof(UIModule), "RaptureLogModule"));
         }
 
         [Fact]
-        public void HardCodedChainOffset_UIModule_RaptureHotbarModule_Is_0x57B80() {
-            Assert.Equal(0x57B80, FieldOffsetAttributeValue(typeof(UIModule), "RaptureHotbarModule"));
+        public void HardCodedChainOffset_UIModule_RaptureHotbarModule_Is_0x57C60() {
+            // Bumped from 0x57B80 → 0x57C60 by the same FCS commit ("Update UIModule").
+            // Same +0xE0 shift as RaptureLogModule — fields added before both modules.
+            Assert.Equal(0x57C60, FieldOffsetAttributeValue(typeof(UIModule), "RaptureHotbarModule"));
         }
 
         [Fact]

--- a/Sharlayan.Tests/Resources/Providers/FCSDependencyIntegrityTests.cs
+++ b/Sharlayan.Tests/Resources/Providers/FCSDependencyIntegrityTests.cs
@@ -213,6 +213,19 @@ namespace Sharlayan.Tests.Resources.Providers {
         }
 
         [Fact]
+        public void HardCodedChainOffset_StatusManager_status_Is_0x8() {
+            // ActorItemMapper / PartyMemberMapper add this to the StatusManager struct
+            // base to land on the first Status slot. If FCS shifts _status (rare — Owner
+            // pointer at +0 is stable), the resolvers would silently read a wrong region.
+            Assert.Equal(0x8, FieldOffsetAttributeValue(typeof(FFXIVClientStructs.FFXIV.Client.Game.StatusManager), "_status"));
+        }
+
+        [Fact]
+        public void PrivateFieldOffset_StatusManager_status_Resolves() {
+            AssertPrivateFieldExists<FFXIVClientStructs.FFXIV.Client.Game.StatusManager>("_status");
+        }
+
+        [Fact]
         public void HardCodedChainOffset_RaptureHotbarModule_hotbars_Is_0xA0() {
             // _hotbars is internal FixedSizeArray18<Hotbar> at +0xA0. Provider adds +0xA0
             // on top of the RaptureHotbarModule offset to land on _hotbars[0].

--- a/Sharlayan/Core/Interfaces/IStatusItem.cs
+++ b/Sharlayan/Core/Interfaces/IStatusItem.cs
@@ -24,6 +24,14 @@ namespace Sharlayan.Core.Interfaces {
 
         string StatusName { get; set; }
 
+        /// <summary>
+        /// Always-English name regardless of <see cref="SharlayanConfiguration.GameLanguage"/>.
+        /// Use for programmatic comparisons against hardcoded English literals (e.g.
+        /// <c>statuses.Find(s =&gt; s.StatusNameEnglish == "Iron Will")</c>); use
+        /// <see cref="StatusName"/> for display.
+        /// </summary>
+        string StatusNameEnglish { get; set; }
+
         ActorItem TargetEntity { get; set; }
 
         string TargetName { get; set; }

--- a/Sharlayan/Core/StatusItem.cs
+++ b/Sharlayan/Core/StatusItem.cs
@@ -26,6 +26,14 @@ namespace Sharlayan.Core {
 
         public string StatusName { get; set; }
 
+        /// <summary>
+        /// Always-English name regardless of <see cref="SharlayanConfiguration.GameLanguage"/>.
+        /// Use for programmatic comparisons against hardcoded English literals (e.g.
+        /// <c>statuses.Find(s =&gt; s.StatusNameEnglish == "Iron Will")</c>); use
+        /// <see cref="StatusName"/> for display.
+        /// </summary>
+        public string StatusNameEnglish { get; set; }
+
         public ActorItem TargetEntity { get; set; }
 
         public string TargetName { get; set; }

--- a/Sharlayan/LuminaLookup.cs
+++ b/Sharlayan/LuminaLookup.cs
@@ -1,0 +1,150 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="LuminaLookup.cs" company="SyndicatedLife">
+//   Copyright© 2007 - 2022 Ryan Wilson <syndicated.life@gmail.com> (https://syndicated.life/)
+//   Licensed under the MIT license. See LICENSE.md in the solution root for full license information.
+// </copyright>
+// <summary>
+//   Public name → row-id helpers backed by Lumina's Excel sheets. Inverse of Reader.Lumina's
+//   id-to-name lookups: given a localised resource name from any client language, return the
+//   universal numeric row id (Weather "Moon Dust" → 148, Action "リフルジェントアロー" → 98).
+//
+//   Each lookup is built lazily on first call by walking all four client languages and
+//   unioning every row's display name into a single case-insensitive dictionary keyed by
+//   sheet type. Subsequent calls hit the cache directly — no repeat sqpack scans.
+//
+//   Per-language failures (e.g. MismatchedColumnHashException during the gap between an
+//   FFXIV patch and a matching Lumina.Excel package release) silently degrade: partial
+//   coverage from the languages that did resolve is better than nothing.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Sharlayan {
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+
+    using Lumina;
+    using Lumina.Data;
+    using Lumina.Excel;
+    using Lumina.Excel.Sheets;
+
+    using Sharlayan.Resources.Providers;
+
+    public static class LuminaLookup {
+        // One name→row-id dictionary per sheet type. Process-wide cache (not Reader-scoped)
+        // because the underlying Lumina GameData is also process-wide via LuminaGameDataCache.
+        // Keyed on the typeof(T) Excel row struct.
+        private static readonly ConcurrentDictionary<Type, IReadOnlyDictionary<string, uint>> _cache =
+            new ConcurrentDictionary<Type, IReadOnlyDictionary<string, uint>>();
+
+        // FFXIV's four primary client languages. We probe each in turn and union the results
+        // so callers can pass a name from any language and get the same row id back.
+        private static readonly Language[] _languages = new[] {
+            Language.English,
+            Language.Japanese,
+            Language.German,
+            Language.French,
+        };
+
+        /// <summary>Translate a Weather row's localised name (e.g. "Moon Dust") to its universal RowId.</summary>
+        public static uint? WeatherIdFromName(SharlayanConfiguration configuration, string name)
+            => FindRowId<Weather>(configuration, name, r => r.Name.ExtractText());
+
+        /// <summary>Translate an Action row's localised name (e.g. "リフルジェントアロー") to its universal RowId.</summary>
+        public static uint? ActionIdFromName(SharlayanConfiguration configuration, string name)
+            => FindRowId<Lumina.Excel.Sheets.Action>(configuration, name, r => r.Name.ExtractText());
+
+        /// <summary>Translate a Status (status effect) row's localised name to its universal RowId.</summary>
+        public static uint? StatusIdFromName(SharlayanConfiguration configuration, string name)
+            => FindRowId<Status>(configuration, name, r => r.Name.ExtractText());
+
+        /// <summary>Translate a PlaceName row's localised name (zones / fields / districts) to its universal RowId.</summary>
+        public static uint? PlaceNameIdFromName(SharlayanConfiguration configuration, string name)
+            => FindRowId<PlaceName>(configuration, name, r => r.Name.ExtractText());
+
+        /// <summary>Translate a ContentFinderCondition (duty / instance / raid) localised name to its universal RowId.</summary>
+        public static uint? ContentFinderConditionIdFromName(SharlayanConfiguration configuration, string name)
+            => FindRowId<ContentFinderCondition>(configuration, name, r => r.Name.ExtractText());
+
+        /// <summary>Translate an Item row's localised name to its universal RowId.</summary>
+        public static uint? ItemIdFromName(SharlayanConfiguration configuration, string name)
+            => FindRowId<Item>(configuration, name, r => r.Name.ExtractText());
+
+        /// <summary>Translate a BNpcName (battle NPC / mob) row's Singular localised name to its universal RowId.</summary>
+        public static uint? BNpcNameIdFromName(SharlayanConfiguration configuration, string name)
+            => FindRowId<BNpcName>(configuration, name, r => r.Singular.ExtractText());
+
+        /// <summary>Translate an ENpcResident (event NPC / friendly NPC) Singular localised name to its universal RowId.</summary>
+        public static uint? ENpcResidentIdFromName(SharlayanConfiguration configuration, string name)
+            => FindRowId<ENpcResident>(configuration, name, r => r.Singular.ExtractText());
+
+        /// <summary>Translate a Mount row's Singular localised name to its universal RowId.</summary>
+        public static uint? MountIdFromName(SharlayanConfiguration configuration, string name)
+            => FindRowId<Mount>(configuration, name, r => r.Singular.ExtractText());
+
+        /// <summary>Translate a Companion (minion) row's Singular localised name to its universal RowId.</summary>
+        public static uint? CompanionIdFromName(SharlayanConfiguration configuration, string name)
+            => FindRowId<Companion>(configuration, name, r => r.Singular.ExtractText());
+
+        /// <summary>
+        /// Lower-level entry point: given a sheet row type and a name selector, return the
+        /// row id whose name matches. Useful for callers that need a sheet not exposed by
+        /// the dedicated helpers above. The cache is keyed on <typeparamref name="T"/> so
+        /// each unique row type gets one lookup table built across all 4 languages.
+        /// </summary>
+        public static uint? FindRowId<T>(SharlayanConfiguration configuration, string name, Func<T, string> nameSelector)
+            where T : struct, IExcelRow<T> {
+            if (string.IsNullOrEmpty(name) || configuration == null || nameSelector == null) {
+                return null;
+            }
+            IReadOnlyDictionary<string, uint> dict = _cache.GetOrAdd(typeof(T), _ => BuildLookup(configuration, nameSelector));
+            return dict.TryGetValue(name, out uint id) ? id : (uint?)null;
+        }
+
+        /// <summary>
+        /// Drops the cached lookups so the next call will rebuild them. Useful if the sqpack
+        /// path or game install changes mid-process. Rare in practice — most callers can
+        /// ignore this.
+        /// </summary>
+        public static void ClearCache() => _cache.Clear();
+
+        private static IReadOnlyDictionary<string, uint> BuildLookup<T>(SharlayanConfiguration configuration, Func<T, string> nameSelector)
+            where T : struct, IExcelRow<T> {
+            // OrdinalIgnoreCase — case-insensitive for Latin scripts; no-op for CJK characters
+            // (they don't have case), so Japanese / Chinese names still match exactly.
+            Dictionary<string, uint> dict = new Dictionary<string, uint>(StringComparer.OrdinalIgnoreCase);
+            GameData lumina = LuminaGameDataCache.GetOrNull(configuration);
+            if (lumina == null) {
+                return dict;
+            }
+
+            foreach (Language lang in _languages) {
+                ExcelSheet<T> sheet;
+                try {
+                    sheet = lumina.Excel.GetSheet<T>(lang);
+                }
+                catch {
+                    // Per-language failure (hash mismatch / schema drift / language not
+                    // available in this sqpack). Skip and try the next language.
+                    continue;
+                }
+                foreach (T row in sheet) {
+                    string nm;
+                    try { nm = nameSelector(row); }
+                    catch { continue; }
+                    if (string.IsNullOrEmpty(nm)) {
+                        continue;
+                    }
+                    // First occurrence wins. In practice the same display name across
+                    // languages points at the same RowId for almost every sheet, so this is
+                    // a stable choice; rare cross-language collisions get the earliest
+                    // language's row.
+                    if (!dict.ContainsKey(nm)) {
+                        dict[nm] = row.RowId;
+                    }
+                }
+            }
+            return dict;
+        }
+    }
+}

--- a/Sharlayan/Models/XIVDatabase/StatusItem.cs
+++ b/Sharlayan/Models/XIVDatabase/StatusItem.cs
@@ -13,5 +13,14 @@ namespace Sharlayan.Models.XIVDatabase {
         public bool CompanyAction { get; set; }
 
         public Localization Name { get; set; }
+
+        /// <summary>
+        /// Max simultaneous stacks per Lumina's Status sheet (<c>MaxStacks</c> column).
+        /// 0 or 1 means the status doesn't stack — its in-memory <c>Status.Param</c> field
+        /// encodes something other than a stack count (food/potion id, or unrelated meta
+        /// for ordinary buffs), so resolvers should leave <c>StatusItem.Stacks</c> at 0
+        /// rather than surfacing the Param byte as a misleading "stacks" value.
+        /// </summary>
+        public byte MaxStacks { get; set; }
     }
 }

--- a/Sharlayan/Reader.GameState.cs
+++ b/Sharlayan/Reader.GameState.cs
@@ -296,15 +296,20 @@ namespace Sharlayan {
             if (lumina == null) {
                 return;
             }
-            try {
-                this._weatherSheetEn = lumina.Excel.GetSheet<Lumina.Excel.Sheets.Weather>();
-                this._bgmSheetEn = lumina.Excel.GetSheet<Lumina.Excel.Sheets.BGM>();
-                this._bgmFadeTypeSheet = lumina.Excel.GetSheet<Lumina.Excel.Sheets.BGMFadeType>();
+            // Each sheet resolves independently — Lumina.Excel throws
+            // MismatchedColumnHashException when the typed schema hash differs from the
+            // current game's EXD (typical during the window between an FFXIV patch and a
+            // matching Lumina.Excel release). Catching per-sheet keeps the still-valid
+            // sheets usable while the broken one falls back to null.
+            try { this._weatherSheetEn   = lumina.Excel.GetSheet<Lumina.Excel.Sheets.Weather>(); }     catch { }
+            try { this._bgmSheetEn       = lumina.Excel.GetSheet<Lumina.Excel.Sheets.BGM>(); }         catch { }
+            try { this._bgmFadeTypeSheet = lumina.Excel.GetSheet<Lumina.Excel.Sheets.BGMFadeType>(); } catch { }
 
-                // Build the scene → BGMFadeType lookup once. BGMFade has (SceneOut, SceneIn,
-                // BGMFadeType) triples — we pick the FIRST row whose SceneIn matches each
-                // scene index 0..11. Multiple rows may match (different SceneOut origins);
-                // first match is a pragmatic default that surfaces a representative preset.
+            // Build the scene → BGMFadeType lookup once. BGMFade has (SceneOut, SceneIn,
+            // BGMFadeType) triples — we pick the FIRST row whose SceneIn matches each
+            // scene index 0..11. Multiple rows may match (different SceneOut origins);
+            // first match is a pragmatic default that surfaces a representative preset.
+            try {
                 var bgmFadeSheet = lumina.Excel.GetSheet<Lumina.Excel.Sheets.BGMFade>();
                 this._scenePresetFadeTypeRowIds = new uint[12];
                 foreach (var row in bgmFadeSheet) {
@@ -315,7 +320,7 @@ namespace Sharlayan {
                     }
                 }
             }
-            catch { /* leave fields null; subsequent calls skip the lookup */ }
+            catch { /* leave _scenePresetFadeTypeRowIds null; preset lookup will skip */ }
         }
 
         // Thin accessor retained so Reader.Lumina can resolve language-specific sheets

--- a/Sharlayan/Resources/Mappers/ActorItemMapper.cs
+++ b/Sharlayan/Resources/Mappers/ActorItemMapper.cs
@@ -19,6 +19,7 @@
 namespace Sharlayan.Resources.Mappers {
     using System.Runtime.InteropServices;
 
+    using FFXIVClientStructs.FFXIV.Client.Game;
     using FFXIVClientStructs.FFXIV.Client.Game.Character;
     using FFXIVClientStructs.FFXIV.Client.Game.Object;
     using FFXIVClientStructs.FFXIV.Common.Math;
@@ -127,6 +128,15 @@ namespace Sharlayan.Resources.Mappers {
                 // StatusManager._status[60] from there.
                 Status          = statusManagerOff,
 
+                // DefaultStatusEffectOffset → byte offset within Character of the FIRST
+                // Status entry (StatusManager._status[0]). ActorItemResolver does a single
+                // BlockCopy from this offset to scan all status slots, so it must point at
+                // the array's first element, not the StatusManager struct base (which has
+                // an `Owner` pointer at +0). _status is internal; resolved via string-name
+                // lookup so FCS field-offset bumps continue to track automatically.
+                DefaultStatusEffectOffset = statusManagerOff
+                                            + FieldOffsetReader.OffsetOf<StatusManager>("_status"),
+
                 // --- Bookkeeping ----------------------------------------------------
                 // SourceSize tells ActorItemResolver how many bytes to read per actor.
                 // Must match the full Character struct size.
@@ -144,7 +154,7 @@ namespace Sharlayan.Resources.Mappers {
                 // consumers need them:
                 //   ActionStatus, AgroFlags, CastingID, CastingProgress, CastingTargetID,
                 //   CastingTime, ClaimedByID, CombatFlags, DefaultBaseOffset,
-                //   DefaultStatOffset, DefaultStatusEffectOffset, DifficultyRank,
+                //   DefaultStatOffset, DifficultyRank,
                 //   EntityCount, EventObjectType, GatheringInvisible, GatheringStatus,
                 //   GrandCompany, GrandCompanyRank, InCutscene, IsCasting1, IsCasting2,
                 //   ModelID, Status, TargetFlags, TargetType.

--- a/Sharlayan/Resources/Mappers/ActorItemMapper.cs
+++ b/Sharlayan/Resources/Mappers/ActorItemMapper.cs
@@ -35,14 +35,25 @@ namespace Sharlayan.Resources.Mappers {
             // Casting & status offsets are BattleChara-relative (0x2790 + field within CastInfo,
             // 0x23B0 for StatusManager). Non-BattleChara actors will read garbage at these
             // offsets, same as the legacy mapping — callers guard on IsCasting1 being truthy.
-            int castInfoBase     = (int)Marshal.OffsetOf<BattleChara>(nameof(BattleChara.CastInfo));
-            int statusManagerOff = (int)Marshal.OffsetOf<BattleChara>(nameof(BattleChara.StatusManager));
-            int ciIsCasting      = (int)Marshal.OffsetOf<CastInfo>(nameof(CastInfo.IsCasting));
-            int ciInterruptible  = (int)Marshal.OffsetOf<CastInfo>(nameof(CastInfo.Interruptible));
-            int ciActionId       = (int)Marshal.OffsetOf<CastInfo>(nameof(CastInfo.ActionId));
-            int ciTargetId       = (int)Marshal.OffsetOf<CastInfo>(nameof(CastInfo.TargetId));
-            int ciCurrentCast    = (int)Marshal.OffsetOf<CastInfo>(nameof(CastInfo.CurrentCastTime));
-            int ciTotalCast      = (int)Marshal.OffsetOf<CastInfo>(nameof(CastInfo.TotalCastTime));
+            // FCS made CastInfo non-marshalable (managed-pointer-bearing field added),
+            // so Marshal.OffsetOf throws even on still-blittable members. FieldOffsetReader
+            // reads the [FieldOffset] attribute via reflection and works regardless of
+            // marshallability — the project's standard fallback for FCS struct evolution.
+            //
+            // CastInfo.IsCasting and CastInfo.Interruptible used to be standalone byte
+            // fields; FCS migrated them to [BitField<bool>] accessors over a single
+            // CastInfo.Flags byte at offset 0 (bit 0 = IsCasting, bit 1 = Interruptible).
+            // We now point IsCasting1/IsCasting2 at the Flags byte; ActorItemResolver does
+            // the per-bit mask. The "still-just-a-byte" semantic is preserved for
+            // IsCasting1 because TryToBoolean returns true for any non-zero byte and bit 0
+            // dominates during a real cast.
+            int castInfoBase     = FieldOffsetReader.OffsetOf<BattleChara>(nameof(BattleChara.CastInfo));
+            int statusManagerOff = FieldOffsetReader.OffsetOf<BattleChara>(nameof(BattleChara.StatusManager));
+            int ciFlags          = FieldOffsetReader.OffsetOf<CastInfo>(nameof(CastInfo.Flags)); // bit 0 = IsCasting, bit 1 = Interruptible
+            int ciActionId       = FieldOffsetReader.OffsetOf<CastInfo>(nameof(CastInfo.ActionId));
+            int ciTargetId       = FieldOffsetReader.OffsetOf<CastInfo>(nameof(CastInfo.TargetId));
+            int ciCurrentCast    = FieldOffsetReader.OffsetOf<CastInfo>(nameof(CastInfo.CurrentCastTime));
+            int ciTotalCast      = FieldOffsetReader.OffsetOf<CastInfo>(nameof(CastInfo.TotalCastTime));
 
             return new ActorItem {
                 // --- GameObject base (offset 0 within Character) ----------------------
@@ -103,8 +114,11 @@ namespace Sharlayan.Resources.Mappers {
                 InCutscene = (int)Marshal.OffsetOf<Character>(nameof(Character.RenderFlags)) + 1,
 
                 // --- BattleChara casting + status (offsets only valid for battle actors) ---
-                IsCasting1      = castInfoBase + ciIsCasting,
-                IsCasting2      = castInfoBase + ciInterruptible,
+                // Both point at the Flags byte; resolver reads it once and bit-tests
+                // (bit 0 → IsCasting, bit 1 → Interruptible). See note above the local
+                // declarations explaining the bitfield migration.
+                IsCasting1      = castInfoBase + ciFlags,
+                IsCasting2      = castInfoBase + ciFlags,
                 CastingID       = castInfoBase + ciActionId,
                 CastingTargetID = castInfoBase + ciTargetId,
                 CastingProgress = castInfoBase + ciCurrentCast,

--- a/Sharlayan/Resources/Mappers/PartyMemberMapper.cs
+++ b/Sharlayan/Resources/Mappers/PartyMemberMapper.cs
@@ -44,10 +44,14 @@ namespace Sharlayan.Resources.Mappers {
 
                 SourceSize = Marshal.SizeOf<NativePartyMember>(),
 
-                // DefaultStatusEffectOffset is Sharlayan-internal bookkeeping. The native
-                // PartyMember.StatusManager sits at offset 0, which is what the old
-                // Sharlayan resolver would compute for this field. Preserving that:
-                DefaultStatusEffectOffset = (int)Marshal.OffsetOf<NativePartyMember>(nameof(NativePartyMember.StatusManager)),
+                // DefaultStatusEffectOffset → byte offset within NativePartyMember of the
+                // FIRST Status entry (StatusManager._status[0]). PartyMemberResolver does a
+                // single BlockCopy from this offset to scan all status slots, so it must
+                // point at the array's first element, not the StatusManager struct base
+                // (which has an `Owner` pointer at +0). _status is internal; resolved via
+                // string-name lookup so FCS field-offset bumps continue to track.
+                DefaultStatusEffectOffset = (int)Marshal.OffsetOf<NativePartyMember>(nameof(NativePartyMember.StatusManager))
+                                            + FieldOffsetReader.OffsetOf<FFXIVClientStructs.FFXIV.Client.Game.StatusManager>("_status"),
             };
         }
     }

--- a/Sharlayan/Resources/Providers/LuminaXivDatabaseProvider.cs
+++ b/Sharlayan/Resources/Providers/LuminaXivDatabaseProvider.cs
@@ -98,6 +98,12 @@ namespace Sharlayan.Resources.Providers {
                             de.HasRow(id) ? de.GetRow(id).Name.ExtractText() : string.Empty,
                             fr.HasRow(id) ? fr.GetRow(id).Name.ExtractText() : string.Empty),
                         CompanyAction = row.IsFcBuff,
+                        // MaxStacks lets resolvers distinguish stacking debuffs (where
+                        // Status.Param = stack count) from non-stacking buffs (where Param
+                        // means something else entirely — food/potion id, etc.). Without
+                        // this, Stacks ends up showing arbitrary Param bytes for every
+                        // status as if everything stacks.
+                        MaxStacks = row.MaxStacks,
                     };
                     statusEffects.AddOrUpdate(id, item, (_, _) => item);
                 }

--- a/Sharlayan/Sharlayan.csproj
+++ b/Sharlayan/Sharlayan.csproj
@@ -51,7 +51,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Lumina" Version="7.3.0" />
+		<PackageReference Include="Lumina" Version="7.4.0" />
 		<PackageReference Include="Lumina.Excel" Version="7.4.3" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="NLog" Version="6.1.2" />

--- a/Sharlayan/Sharlayan.xml
+++ b/Sharlayan/Sharlayan.xml
@@ -54,6 +54,22 @@
             message timestamp
             </summary>
         </member>
+        <member name="P:Sharlayan.Core.Interfaces.IStatusItem.StatusNameEnglish">
+            <summary>
+            Always-English name regardless of <see cref="P:Sharlayan.SharlayanConfiguration.GameLanguage"/>.
+            Use for programmatic comparisons against hardcoded English literals (e.g.
+            <c>statuses.Find(s =&gt; s.StatusNameEnglish == "Iron Will")</c>); use
+            <see cref="P:Sharlayan.Core.Interfaces.IStatusItem.StatusName"/> for display.
+            </summary>
+        </member>
+        <member name="P:Sharlayan.Core.StatusItem.StatusNameEnglish">
+            <summary>
+            Always-English name regardless of <see cref="P:Sharlayan.SharlayanConfiguration.GameLanguage"/>.
+            Use for programmatic comparisons against hardcoded English literals (e.g.
+            <c>statuses.Find(s =&gt; s.StatusNameEnglish == "Iron Will")</c>); use
+            <see cref="P:Sharlayan.Core.StatusItem.StatusName"/> for display.
+            </summary>
+        </member>
         <member name="M:Sharlayan.LuminaLookup.WeatherIdFromName(Sharlayan.SharlayanConfiguration,System.String)">
             <summary>Translate a Weather row's localised name (e.g. "Moon Dust") to its universal RowId.</summary>
         </member>
@@ -299,6 +315,15 @@
             Set to false if SoundManager isn't resolved.
             </summary>
         </member>
+        <member name="P:Sharlayan.Models.XIVDatabase.StatusItem.MaxStacks">
+            <summary>
+            Max simultaneous stacks per Lumina's Status sheet (<c>MaxStacks</c> column).
+            0 or 1 means the status doesn't stack — its in-memory <c>Status.Param</c> field
+            encodes something other than a stack count (food/potion id, or unrelated meta
+            for ordinary buffs), so resolvers should leave <c>StatusItem.Stacks</c> at 0
+            rather than surfacing the Param byte as a misleading "stacks" value.
+            </summary>
+        </member>
         <member name="M:Sharlayan.Reader.GetZoneName(System.UInt32,System.String)">
             <summary>
             Resolve a TerritoryType row id to its PlaceName in the requested language.
@@ -380,6 +405,14 @@
             Returns the cached <see cref="T:Lumina.GameData"/> for the configuration's sqpack path,
             throwing if the path can't be resolved. Used by the xivdatabase provider's bulk
             loaders where a missing sqpack is a genuine configuration error.
+            </summary>
+        </member>
+        <member name="M:Sharlayan.Utilities.LocalizationHelper.SelectLocalized(Sharlayan.Models.Localization,Sharlayan.Enums.GameLanguage)">
+            <summary>
+            Returns the localised string for <paramref name="language"/>. Falls back to
+            English when the requested language slot is null or when the language enum is
+            <see cref="F:Sharlayan.Enums.GameLanguage.English"/> (the default). Returns null only if the
+            <paramref name="names"/> argument itself is null.
             </summary>
         </member>
     </members>

--- a/Sharlayan/Sharlayan.xml
+++ b/Sharlayan/Sharlayan.xml
@@ -54,6 +54,51 @@
             message timestamp
             </summary>
         </member>
+        <member name="M:Sharlayan.LuminaLookup.WeatherIdFromName(Sharlayan.SharlayanConfiguration,System.String)">
+            <summary>Translate a Weather row's localised name (e.g. "Moon Dust") to its universal RowId.</summary>
+        </member>
+        <member name="M:Sharlayan.LuminaLookup.ActionIdFromName(Sharlayan.SharlayanConfiguration,System.String)">
+            <summary>Translate an Action row's localised name (e.g. "リフルジェントアロー") to its universal RowId.</summary>
+        </member>
+        <member name="M:Sharlayan.LuminaLookup.StatusIdFromName(Sharlayan.SharlayanConfiguration,System.String)">
+            <summary>Translate a Status (status effect) row's localised name to its universal RowId.</summary>
+        </member>
+        <member name="M:Sharlayan.LuminaLookup.PlaceNameIdFromName(Sharlayan.SharlayanConfiguration,System.String)">
+            <summary>Translate a PlaceName row's localised name (zones / fields / districts) to its universal RowId.</summary>
+        </member>
+        <member name="M:Sharlayan.LuminaLookup.ContentFinderConditionIdFromName(Sharlayan.SharlayanConfiguration,System.String)">
+            <summary>Translate a ContentFinderCondition (duty / instance / raid) localised name to its universal RowId.</summary>
+        </member>
+        <member name="M:Sharlayan.LuminaLookup.ItemIdFromName(Sharlayan.SharlayanConfiguration,System.String)">
+            <summary>Translate an Item row's localised name to its universal RowId.</summary>
+        </member>
+        <member name="M:Sharlayan.LuminaLookup.BNpcNameIdFromName(Sharlayan.SharlayanConfiguration,System.String)">
+            <summary>Translate a BNpcName (battle NPC / mob) row's Singular localised name to its universal RowId.</summary>
+        </member>
+        <member name="M:Sharlayan.LuminaLookup.ENpcResidentIdFromName(Sharlayan.SharlayanConfiguration,System.String)">
+            <summary>Translate an ENpcResident (event NPC / friendly NPC) Singular localised name to its universal RowId.</summary>
+        </member>
+        <member name="M:Sharlayan.LuminaLookup.MountIdFromName(Sharlayan.SharlayanConfiguration,System.String)">
+            <summary>Translate a Mount row's Singular localised name to its universal RowId.</summary>
+        </member>
+        <member name="M:Sharlayan.LuminaLookup.CompanionIdFromName(Sharlayan.SharlayanConfiguration,System.String)">
+            <summary>Translate a Companion (minion) row's Singular localised name to its universal RowId.</summary>
+        </member>
+        <member name="M:Sharlayan.LuminaLookup.FindRowId``1(Sharlayan.SharlayanConfiguration,System.String,System.Func{``0,System.String})">
+            <summary>
+            Lower-level entry point: given a sheet row type and a name selector, return the
+            row id whose name matches. Useful for callers that need a sheet not exposed by
+            the dedicated helpers above. The cache is keyed on <typeparamref name="T"/> so
+            each unique row type gets one lookup table built across all 4 languages.
+            </summary>
+        </member>
+        <member name="M:Sharlayan.LuminaLookup.ClearCache">
+            <summary>
+            Drops the cached lookups so the next call will rebuild them. Useful if the sqpack
+            path or game install changes mid-process. Rare in practice — most callers can
+            ignore this.
+            </summary>
+        </member>
         <member name="T:Sharlayan.Models.ReadResults.BgmSceneType">
             <summary>
             Index into <see cref="P:Sharlayan.Models.ReadResults.GameStateResult.BgmScenes"/>. Mirrors the FFXIVClientStructs

--- a/Sharlayan/Utilities/ActorItemResolver.cs
+++ b/Sharlayan/Utilities/ActorItemResolver.cs
@@ -126,7 +126,13 @@ namespace Sharlayan.Utilities {
 
                 // entry.Race = source[0x2578]; // ??
                 // entry.Sex = (Actor.Sex) source[0x2579]; //?
-                entry.IsCasting1 = SharlayanBitConverter.TryToBoolean(source, this._memoryHandler.Structures.ActorItem.IsCasting1);
+                // FCS migrated CastInfo.IsCasting / .Interruptible to bit accessors over a
+                // single Flags byte (bit 0 = IsCasting). Mapper points IsCasting1 at the
+                // Flags byte; mask bit 0 here. Behaviour is unchanged from the old standalone
+                // boolean field — any in-progress cast still flips IsCasting1 to true.
+                int isCastingOff = this._memoryHandler.Structures.ActorItem.IsCasting1;
+                entry.IsCasting1 = isCastingOff >= 0 && isCastingOff < source.Length
+                                   && (source[isCastingOff] & 0x01) != 0;
                 if (this._memoryHandler.Structures.ActorItem.AgroFlags >= 0 && this._memoryHandler.Structures.ActorItem.AgroFlags < source.Length) entry.AgroFlags = source[this._memoryHandler.Structures.ActorItem.AgroFlags];
                 if (this._memoryHandler.Structures.ActorItem.CombatFlags >= 0 && this._memoryHandler.Structures.ActorItem.CombatFlags < source.Length) entry.CombatFlags = source[this._memoryHandler.Structures.ActorItem.CombatFlags];
                 if (this._memoryHandler.Structures.ActorItem.DifficultyRank >= 0 && this._memoryHandler.Structures.ActorItem.DifficultyRank < source.Length) entry.DifficultyRank = source[this._memoryHandler.Structures.ActorItem.DifficultyRank];

--- a/Sharlayan/Utilities/ActorItemResolver.cs
+++ b/Sharlayan/Utilities/ActorItemResolver.cs
@@ -206,30 +206,20 @@ namespace Sharlayan.Utilities {
                             Models.XIVDatabase.StatusItem statusInfo = StatusEffectLookup.GetStatusInfo((uint) statusEntry.StatusID);
                             if (statusInfo != null) {
                                 statusEntry.IsCompanyAction = statusInfo.CompanyAction;
-                                string statusKey = statusInfo.Name.English;
-                                switch (this._memoryHandler.Configuration.GameLanguage) {
-                                    case GameLanguage.French:
-                                        statusKey = statusInfo.Name.French;
-                                        break;
-                                    case GameLanguage.Japanese:
-                                        statusKey = statusInfo.Name.Japanese;
-                                        break;
-                                    case GameLanguage.German:
-                                        statusKey = statusInfo.Name.German;
-                                        break;
-                                    case GameLanguage.Chinese:
-                                        statusKey = statusInfo.Name.Chinese;
-                                        break;
-                                    case GameLanguage.Korean:
-                                        statusKey = statusInfo.Name.Korean;
-                                        break;
+                                statusEntry.StatusName        = LocalizationHelper.SelectLocalized(statusInfo.Name, this._memoryHandler.Configuration.GameLanguage);
+                                statusEntry.StatusNameEnglish = statusInfo.Name?.English ?? Constants.UNKNOWN_LOCALIZED_NAME;
+                                // Status.Param means "stack count" only for stacking statuses
+                                // (Lumina Status.MaxStacks > 1). For everything else it's an
+                                // unrelated payload (food/potion id, internal modifier) — zero
+                                // it so consumers don't mistake it for a real stack count.
+                                if (statusInfo.MaxStacks <= 1) {
+                                    statusEntry.Stacks = 0;
                                 }
-
-                                statusEntry.StatusName = statusKey;
                             }
                         }
                         catch (Exception) {
-                            statusEntry.StatusName = Constants.UNKNOWN_LOCALIZED_NAME;
+                            statusEntry.StatusName        = Constants.UNKNOWN_LOCALIZED_NAME;
+                            statusEntry.StatusNameEnglish = Constants.UNKNOWN_LOCALIZED_NAME;
                         }
 
                         if (statusEntry.IsValid()) {

--- a/Sharlayan/Utilities/LocalizationHelper.cs
+++ b/Sharlayan/Utilities/LocalizationHelper.cs
@@ -1,0 +1,39 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="LocalizationHelper.cs" company="SyndicatedLife">
+//   Copyright© 2007 - 2022 Ryan Wilson <syndicated.life@gmail.com> (https://syndicated.life/)
+//   Licensed under the MIT license. See LICENSE.md in the solution root for full license information.
+// </copyright>
+// <summary>
+//   Pure helper that picks the right field off a <see cref="Sharlayan.Models.Localization"/>
+//   record given a <see cref="Sharlayan.Enums.GameLanguage"/>. Extracted from the duplicated
+//   switch blocks in ActorItemResolver / PartyMemberResolver so the language-selection logic
+//   can be unit tested without spinning up a MemoryHandler.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Sharlayan.Utilities {
+    using Sharlayan.Enums;
+    using Sharlayan.Models;
+
+    internal static class LocalizationHelper {
+        /// <summary>
+        /// Returns the localised string for <paramref name="language"/>. Falls back to
+        /// English when the requested language slot is null or when the language enum is
+        /// <see cref="GameLanguage.English"/> (the default). Returns null only if the
+        /// <paramref name="names"/> argument itself is null.
+        /// </summary>
+        public static string SelectLocalized(Localization names, GameLanguage language) {
+            if (names == null) {
+                return null;
+            }
+            switch (language) {
+                case GameLanguage.French:   return names.French   ?? names.English;
+                case GameLanguage.Japanese: return names.Japanese ?? names.English;
+                case GameLanguage.German:   return names.German   ?? names.English;
+                case GameLanguage.Chinese:  return names.Chinese  ?? names.English;
+                case GameLanguage.Korean:   return names.Korean   ?? names.English;
+                default:                    return names.English;
+            }
+        }
+    }
+}

--- a/Sharlayan/Utilities/PartyMemberResolver.cs
+++ b/Sharlayan/Utilities/PartyMemberResolver.cs
@@ -129,30 +129,19 @@ namespace Sharlayan.Utilities {
                             if (statusEntry.StatusID > 0) {
                                 Models.XIVDatabase.StatusItem statusInfo = StatusEffectLookup.GetStatusInfo((uint) statusEntry.StatusID);
                                 statusEntry.IsCompanyAction = statusInfo.CompanyAction;
-                                string statusKey = statusInfo.Name.English;
-                                switch (this._memoryHandler.Configuration.GameLanguage) {
-                                    case GameLanguage.French:
-                                        statusKey = statusInfo.Name.French;
-                                        break;
-                                    case GameLanguage.Japanese:
-                                        statusKey = statusInfo.Name.Japanese;
-                                        break;
-                                    case GameLanguage.German:
-                                        statusKey = statusInfo.Name.German;
-                                        break;
-                                    case GameLanguage.Chinese:
-                                        statusKey = statusInfo.Name.Chinese;
-                                        break;
-                                    case GameLanguage.Korean:
-                                        statusKey = statusInfo.Name.Korean;
-                                        break;
+                                statusEntry.StatusName        = LocalizationHelper.SelectLocalized(statusInfo.Name, this._memoryHandler.Configuration.GameLanguage);
+                                statusEntry.StatusNameEnglish = statusInfo.Name?.English ?? Constants.UNKNOWN_LOCALIZED_NAME;
+                                // See ActorItemResolver — Status.Param is only a stack count
+                                // for stacking statuses; zero it out otherwise so consumers
+                                // don't surface random Param bytes as fake stacks.
+                                if (statusInfo.MaxStacks <= 1) {
+                                    statusEntry.Stacks = 0;
                                 }
-
-                                statusEntry.StatusName = statusKey;
                             }
                         }
                         catch (Exception) {
-                            statusEntry.StatusName = Constants.UNKNOWN_LOCALIZED_NAME;
+                            statusEntry.StatusName        = Constants.UNKNOWN_LOCALIZED_NAME;
+                            statusEntry.StatusNameEnglish = Constants.UNKNOWN_LOCALIZED_NAME;
                         }
 
                         if (statusEntry.IsValid()) {

--- a/Sharlayan/version.props
+++ b/Sharlayan/version.props
@@ -5,7 +5,7 @@
          Patch: incremented by Claude/AI on each substantive code change to Sharlayan. -->
     <VersionMajor>9</VersionMajor>
     <VersionMinor>0</VersionMinor>
-    <VersionPatch>29</VersionPatch>
+    <VersionPatch>30</VersionPatch>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Derived version strings — do not edit these directly. -->

--- a/Sharlayan/version.props
+++ b/Sharlayan/version.props
@@ -5,7 +5,7 @@
          Patch: incremented by Claude/AI on each substantive code change to Sharlayan. -->
     <VersionMajor>9</VersionMajor>
     <VersionMinor>0</VersionMinor>
-    <VersionPatch>25</VersionPatch>
+    <VersionPatch>26</VersionPatch>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Derived version strings — do not edit these directly. -->

--- a/Sharlayan/version.props
+++ b/Sharlayan/version.props
@@ -5,7 +5,7 @@
          Patch: incremented by Claude/AI on each substantive code change to Sharlayan. -->
     <VersionMajor>9</VersionMajor>
     <VersionMinor>0</VersionMinor>
-    <VersionPatch>22</VersionPatch>
+    <VersionPatch>23</VersionPatch>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Derived version strings — do not edit these directly. -->

--- a/Sharlayan/version.props
+++ b/Sharlayan/version.props
@@ -5,7 +5,7 @@
          Patch: incremented by Claude/AI on each substantive code change to Sharlayan. -->
     <VersionMajor>9</VersionMajor>
     <VersionMinor>0</VersionMinor>
-    <VersionPatch>18</VersionPatch>
+    <VersionPatch>22</VersionPatch>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Derived version strings — do not edit these directly. -->

--- a/Sharlayan/version.props
+++ b/Sharlayan/version.props
@@ -5,7 +5,7 @@
          Patch: incremented by Claude/AI on each substantive code change to Sharlayan. -->
     <VersionMajor>9</VersionMajor>
     <VersionMinor>0</VersionMinor>
-    <VersionPatch>23</VersionPatch>
+    <VersionPatch>24</VersionPatch>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Derived version strings — do not edit these directly. -->

--- a/Sharlayan/version.props
+++ b/Sharlayan/version.props
@@ -5,7 +5,7 @@
          Patch: incremented by Claude/AI on each substantive code change to Sharlayan. -->
     <VersionMajor>9</VersionMajor>
     <VersionMinor>0</VersionMinor>
-    <VersionPatch>24</VersionPatch>
+    <VersionPatch>25</VersionPatch>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Derived version strings — do not edit these directly. -->

--- a/Sharlayan/version.props
+++ b/Sharlayan/version.props
@@ -5,7 +5,7 @@
          Patch: incremented by Claude/AI on each substantive code change to Sharlayan. -->
     <VersionMajor>9</VersionMajor>
     <VersionMinor>0</VersionMinor>
-    <VersionPatch>26</VersionPatch>
+    <VersionPatch>29</VersionPatch>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Derived version strings — do not edit these directly. -->


### PR DESCRIPTION
## Summary

Patch-day support for FFXIV 5.5 "Trail to the Heavens" plus a batch of API additions and resolver bug fixes that surfaced during the cross-language audit work.

## Patch-day dependency bumps

| Dep | From | To |
|---|---|---|
| FFXIVClientStructs | `4ad7d0d72` | `6ea6cd2d1` (~50 commits — `Update structs`, `Update UIModule`, `Update UIState`, `Update PlayerState`, `Update signatures`, AddonLookingForGroup rename, CastInfo bitfield migration, `Update EventFramework`, etc.) |
| Lumina | 7.3.0 | 7.4.0 |
| Lumina.Excel | 7.4.3 | 7.4.3 (latest published; per-sheet hash-mismatch tolerated by `Reader.GameState.EnsureLuminaSheets`) |

### Layout shifts auto-tracked at runtime; only test pins needed bumping
- `UIModule.RaptureLogModule` `0x19E0 → 0x1AC0`
- `UIModule.RaptureHotbarModule` `0x57B80 → 0x57C60`
- `PlayerState` size `0x908 → 0x920` (harness pin)
- `Vector3` size `0xC → 0x10` (FCS gave it SIMD alignment; field offsets X/Y/Z @ 0/4/8 unchanged)

### CastInfo bitfield migration absorbed
FCS migrated `CastInfo.IsCasting` and `CastInfo.Interruptible` from standalone byte fields to `[BitField<bool>]` accessors over a single `Flags` byte, AND made the struct non-marshalable. `ActorItemMapper` switched from `Marshal.OffsetOf<CastInfo>` to `FieldOffsetReader.OffsetOf`; `IsCasting1` / `IsCasting2` schema offsets now point at `Flags`; `ActorItemResolver` does the bit-0 mask. Downstream `entry.IsCasting1` semantic preserved.

## New public API: `Sharlayan.LuminaLookup`

Name → universal row id helpers across 10 sheets — inverse of `Reader.Lumina`'s id-to-name helpers.

| Method | Resource | Field |
|---|---|---|
| `WeatherIdFromName` | Weather | `Name` |
| `ActionIdFromName` | Action | `Name` |
| `StatusIdFromName` | Status | `Name` |
| `PlaceNameIdFromName` | Zone / field | `Name` |
| `ContentFinderConditionIdFromName` | Duty / instance | `Name` |
| `ItemIdFromName` | Item | `Name` |
| `BNpcNameIdFromName` | Battle NPC | `Singular` |
| `ENpcResidentIdFromName` | Friendly NPC | `Singular` |
| `MountIdFromName` | Mount | `Singular` |
| `CompanionIdFromName` | Minion | `Singular` |
| `FindRowId<T>(config, name, selector)` | Generic escape hatch | caller-provided |

One process-wide `Dictionary<string, uint>` per sheet type, lazy-built across all 4 client languages and unioned with `OrdinalIgnoreCase`. Pass `"Moon Dust"`, `"快晴"`, or `"Mondstaub"` and get the same row id back. Per-language failures (hash mismatch during patch-day) silently degrade.

## Cross-language consumer safety: `StatusNameEnglish`

New `StatusItem.StatusNameEnglish` property — always English regardless of `Configuration.GameLanguage`. Existing `StatusName` remains the localized display value. Consumers comparing against hardcoded English literals (`statuses.Find(s => s.StatusNameEnglish == "Iron Will")`) now stay correct on JP/DE/FR clients.

Audit confirmed `StatusName` was the only resolver field switching on `GameLanguage`. Actor names / target names / action names / chat are either locale-neutral (live memory) or display-only with no English-comparison use case.

The duplicated 5-case language switch in both resolvers became a single `LocalizationHelper.SelectLocalized` call.

## Resolver bug fixes

### `DefaultStatusEffectOffset` was reading garbage
`ActorItemMapper` left `DefaultStatusEffectOffset` at the default `0`, so the resolver's `BlockCopy` was reading status entries from the **start of the Character struct** — pure garbage IDs and stale slots. Same bug in `PartyMemberMapper` (pointed at the `StatusManager` struct base instead of `_status[0]`, off by 8 bytes for the `Owner` pointer prefix). Both now resolve `StatusManager._status` via `FieldOffsetReader`. Pinned via new integrity test.

### `Stacks` gating
FCS `Status.Param` documents itself as *"stack count for debuffs; food/potion id otherwise; meaningless for ordinary buffs"*. The mapper read it as `Stacks` for every status, surfacing arbitrary Param bytes as fake stack counts (e.g. `Reduced Rates Stacks=30`). Both resolvers now zero `Stacks` when `statusInfo.MaxStacks <= 1`, sourced from a new `MaxStacks` property on `Models.XIVDatabase.StatusItem` populated from Lumina's Status sheet.

## Resilience

- `Reader.GameState.EnsureLuminaSheets` resolves `Weather` / `BGM` / `BGMFadeType` / `BGMFade` in independent try/catches — a hash mismatch on one sheet no longer voids the others.
- Harness `[4]` block probes each typed sheet independently and prints `✓ <RowCount>` or `✗ <ExceptionType>: <Message>` per sheet so the exact sheet(s) blocked by a schema-version gap are visible.

## Test plan

- [x] `dotnet test` — 179/179 passing (~+43 new tests vs main)
- [x] Debug build + deploy to Chromatics Build Dependencies
- [x] Live verify against patched FFXIV client — 22 scanner keys resolve; per-scene BGM, status names (English + localized), and per-status Stacks all correct
- [x] `LuminaLookup` smoke test (harness `[5]`) — Weather / Action / Status / PlaceName / ContentFinderCondition / Item / BNpcName / ENpcResident / Mount / Companion lookups working with English + Japanese inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)