### PR TITLE
fix: zone-transition latch + FCS 7.51 + Lumina 7.5 + ILRepack 2.0.45

### DIFF
--- a/Sharlayan.Tests/LoggedInStateLatchTests.cs
+++ b/Sharlayan.Tests/LoggedInStateLatchTests.cs
@@ -1,0 +1,172 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="LoggedInStateLatchTests.cs" company="SyndicatedLife">
+//   Copyright© 2007 - 2026 Ryan Wilson <syndicated.life@gmail.com> (https://syndicated.life/)
+//   Licensed under the MIT license. See LICENSE.md in the solution root for full license information.
+// </copyright>
+// <summary>
+//   Covers Sharlayan.Utilities.LoggedInStateLatch — the debouncer that holds the
+//   last-known local-player Entity across the transient null reads FFXIV produces
+//   during zone transitions. Direct unit tests here prove the present → transient →
+//   present and present → sustained-absent transitions without standing up a Reader
+//   or memory backend.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Sharlayan.Tests {
+    using Sharlayan.Core;
+    using Sharlayan.Utilities;
+
+    using Xunit;
+
+    public class LoggedInStateLatchTests {
+        private static ActorItem Present(uint id = 0x10000001u) {
+            return new ActorItem { ID = id };
+        }
+
+        [Fact]
+        public void Apply_LiveEntity_PassesThrough() {
+            LoggedInStateLatch latch = new LoggedInStateLatch(10);
+            ActorItem live = Present();
+
+            ActorItem result = latch.Apply(live);
+
+            Assert.Same(live, result);
+            Assert.Equal(0, latch.ConsecutiveAbsent);
+        }
+
+        [Fact]
+        public void Apply_NullBeforeAnyLive_ReturnsNull() {
+            LoggedInStateLatch latch = new LoggedInStateLatch(10);
+
+            ActorItem result = latch.Apply(null);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Apply_ZoneTransition_HoldsLastKnownEntity() {
+            // Simulates the FFXIV pattern: live → transient null for a few reads (zone
+            // change) → live again. The latch should hide the null window from callers.
+            LoggedInStateLatch latch = new LoggedInStateLatch(maxConsecutiveAbsent: 10);
+            ActorItem player = Present();
+
+            // Steady state.
+            Assert.Same(player, latch.Apply(player));
+
+            // Zone transition: actor table briefly null for 3 ticks.
+            for (int i = 0; i < 3; i++) {
+                ActorItem latched = latch.Apply(null);
+                Assert.Same(player, latched);
+                Assert.NotEqual(0u, latched.ID);
+            }
+
+            // Actor table populated again.
+            Assert.Same(player, latch.Apply(player));
+            Assert.Equal(0, latch.ConsecutiveAbsent);
+        }
+
+        [Fact]
+        public void Apply_SustainedAbsence_EventuallyReturnsNull() {
+            // Simulates a real logout: live → underlying read stays null forever. The
+            // latch must give up after maxConsecutiveAbsent calls and let null surface,
+            // so consumers' "logged out" detection still fires.
+            LoggedInStateLatch latch = new LoggedInStateLatch(maxConsecutiveAbsent: 5);
+            ActorItem player = Present();
+            Assert.Same(player, latch.Apply(player));
+
+            // Within the latch window — still returns cached.
+            for (int i = 1; i <= 5; i++) {
+                Assert.Same(player, latch.Apply(null));
+            }
+
+            // One past threshold — cache is cleared, null surfaces.
+            Assert.Null(latch.Apply(null));
+            // Subsequent nulls also surface (cache stays cleared).
+            Assert.Null(latch.Apply(null));
+        }
+
+        [Fact]
+        public void Apply_LivePresentResetsCounter_AfterPartialAbsence() {
+            // If a transient absence ends BEFORE the threshold is hit, the absence
+            // counter must reset so the next zone transition gets the full window.
+            LoggedInStateLatch latch = new LoggedInStateLatch(maxConsecutiveAbsent: 5);
+            ActorItem player = Present();
+            latch.Apply(player);
+
+            // 3 transient nulls (not enough to clear cache).
+            Assert.Same(player, latch.Apply(null));
+            Assert.Same(player, latch.Apply(null));
+            Assert.Same(player, latch.Apply(null));
+
+            // Live again — counter resets.
+            Assert.Same(player, latch.Apply(player));
+            Assert.Equal(0, latch.ConsecutiveAbsent);
+
+            // Another 5 transient nulls — must still latch all 5 (proves the counter
+            // started over, not continued from 3).
+            for (int i = 1; i <= 5; i++) {
+                Assert.Same(player, latch.Apply(null));
+            }
+        }
+
+        [Fact]
+        public void Apply_ZeroIdEntity_TreatedAsAbsent() {
+            // GameObjectManager occasionally returns a slot with a half-initialised
+            // Character struct (ID still 0) mid-rebuild. We treat ID==0 the same as
+            // null — neither is a "real" present player.
+            LoggedInStateLatch latch = new LoggedInStateLatch(maxConsecutiveAbsent: 5);
+            ActorItem player = Present();
+            latch.Apply(player);
+
+            ActorItem halfInit = new ActorItem { ID = 0u };
+            Assert.Same(player, latch.Apply(halfInit));
+            Assert.Equal(1, latch.ConsecutiveAbsent);
+        }
+
+        [Fact]
+        public void Apply_NewLivePresent_ReplacesCache() {
+            // If a different character logs in (or the player ID changes for any
+            // reason), the latch should hand back the freshest live value, not the
+            // stale cached one.
+            LoggedInStateLatch latch = new LoggedInStateLatch(maxConsecutiveAbsent: 10);
+            ActorItem original = Present(0x10000001u);
+            ActorItem replacement = Present(0x20000002u);
+
+            latch.Apply(original);
+            ActorItem result = latch.Apply(replacement);
+
+            Assert.Same(replacement, result);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void Apply_NonPositiveThreshold_DisablesLatch(int threshold) {
+            // Threshold 0 (or negative) is the documented kill-switch — consumers who
+            // want the raw underlying read should see null pass straight through.
+            LoggedInStateLatch latch = new LoggedInStateLatch(threshold);
+            ActorItem player = Present();
+
+            Assert.Same(player, latch.Apply(player));
+            Assert.Null(latch.Apply(null));
+            Assert.Null(latch.Apply(null));
+        }
+
+        [Fact]
+        public void Apply_RepeatedZoneTransitions_EachGetsFullLatchWindow() {
+            // Real-world scenario: a teleport, then a few seconds of play, then another
+            // teleport. Each transient window should get the full latch budget — this
+            // is the integration-level guarantee on top of the partial-absence reset.
+            LoggedInStateLatch latch = new LoggedInStateLatch(maxConsecutiveAbsent: 3);
+            ActorItem player = Present();
+
+            for (int round = 0; round < 4; round++) {
+                latch.Apply(player);
+                for (int i = 1; i <= 3; i++) {
+                    Assert.Same(player, latch.Apply(null));
+                }
+                latch.Apply(player); // back to steady state
+            }
+        }
+    }
+}

--- a/Sharlayan/Reader.CurrentPlayer.cs
+++ b/Sharlayan/Reader.CurrentPlayer.cs
@@ -37,7 +37,13 @@ namespace Sharlayan {
         public CurrentPlayerResult GetCurrentPlayer() {
             CurrentPlayerResult result = new CurrentPlayerResult();
 
-            result.Entity = this.GetCurrentPlayerEntity();
+            // FFXIV zeroes the local-player slot in GameObjectManager for 1–3 reads during
+            // any zone transition while the actor table rebuilds. The latch holds the
+            // last-known Entity over that transient window so downstream consumers don't
+            // see Entity flip to null mid-zone. Threshold is SharlayanConfiguration.LoggedInLatchTicks
+            // (default 10); set to 0 to disable.
+            ActorItem live = this.GetCurrentPlayerEntity();
+            result.Entity = this._loggedInStateLatch.Apply(live);
             result.PlayerInfo = this.GetPlayerInfo();
 
             return result;

--- a/Sharlayan/Reader.cs
+++ b/Sharlayan/Reader.cs
@@ -44,7 +44,10 @@ namespace Sharlayan {
             this._playerInfoResolver = new PlayerInfoResolver(this._memoryHandler);
             this._partyMemberResolver = new PartyMemberResolver(this._memoryHandler, this._pcWorkerDelegate, this._npcWorkerDelegate, this._monsterWorkerDelegate);
             this._jobResourceResolver = new JobResourceResolver(this._memoryHandler);
+            this._loggedInStateLatch = new LoggedInStateLatch(this._memoryHandler.Configuration?.LoggedInLatchTicks ?? 0);
         }
+
+        private readonly LoggedInStateLatch _loggedInStateLatch;
 
         private MemoryHandler _memoryHandler { get; }
 

--- a/Sharlayan/Sharlayan.csproj
+++ b/Sharlayan/Sharlayan.csproj
@@ -51,7 +51,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Lumina" Version="7.4.0" />
+		<PackageReference Include="Lumina" Version="7.5.0" />
 		<PackageReference Include="Lumina.Excel" Version="7.4.3" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="NLog" Version="6.1.3" />

--- a/Sharlayan/Sharlayan.csproj
+++ b/Sharlayan/Sharlayan.csproj
@@ -56,7 +56,7 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="NLog" Version="6.1.3" />
 		<PackageReference Include="NLog.Schema" Version="6.1.3" />
-		<PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.44.2" PrivateAssets="all" />
+		<PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.45" PrivateAssets="all" />
 	</ItemGroup>
 
 	<!-- Test-only access for internal members (e.g. MapLanguage in Reader.Lumina.cs).

--- a/Sharlayan/Sharlayan.xml
+++ b/Sharlayan/Sharlayan.xml
@@ -415,12 +415,42 @@
             headers" case); any other exception still bubbles since it indicates a real fault.
             </summary>
         </member>
+        <member name="P:Sharlayan.SharlayanConfiguration.LoggedInLatchTicks">
+            <summary>
+            Maximum number of consecutive <c>GetCurrentPlayer()</c> calls that may return a
+            transient null Entity before the Reader stops latching the last-known value and
+            lets null surface. Zero (or negative) disables the latch entirely.
+            <para>
+            FFXIV zeroes the local-player slot in GameObjectManager for 1–3 reads during any
+            zone transition while the actor table rebuilds. Latching the last-known Entity
+            over that window keeps <see cref="P:Sharlayan.Models.ReadResults.GameStateResult.IsLoggedIn"/>
+            and <see cref="P:Sharlayan.Models.ReadResults.CurrentPlayerResult.Entity"/> stable across the
+            transition. A genuine logout still surfaces once the underlying read has been null
+            for more than this many consecutive calls.
+            </para>
+            <para>
+            Default is 10. At a 5 Hz poll cadence (Chromatics' default) this gives roughly a
+            2-second decay; at 10 Hz roughly 1 second. Tune to your consumer's cadence — you
+            want enough headroom to cover the 1–3 tick transient window without making a real
+            logout take noticeably long to register.
+            </para>
+            </summary>
+        </member>
         <member name="M:Sharlayan.Utilities.LocalizationHelper.SelectLocalized(Sharlayan.Models.Localization,Sharlayan.Enums.GameLanguage)">
             <summary>
             Returns the localised string for <paramref name="language"/>. Falls back to
             English when the requested language slot is null or when the language enum is
             <see cref="F:Sharlayan.Enums.GameLanguage.English"/> (the default). Returns null only if the
             <paramref name="names"/> argument itself is null.
+            </summary>
+        </member>
+        <member name="M:Sharlayan.Utilities.LoggedInStateLatch.Apply(Sharlayan.Core.ActorItem)">
+            <summary>
+            Returns <paramref name="live"/> when it represents a present local player
+            (non-null Entity with non-zero ID). Otherwise returns the most recently cached
+            present Entity if the latch hasn't expired, falling through to <paramref name="live"/>
+            (typically null) once the underlying read has stayed absent for more than
+            <c>maxConsecutiveAbsent</c> consecutive calls.
             </summary>
         </member>
     </members>

--- a/Sharlayan/SharlayanConfiguration.cs
+++ b/Sharlayan/SharlayanConfiguration.cs
@@ -21,5 +21,26 @@ namespace Sharlayan {
         public ProcessModel ProcessModel { get; set; }
         public ResourceProviderKind ResourceProvider { get; set; } = ResourceProviderKind.FFXIVClientStructsDirect;
         public bool ScanAllRegions { get; set; } = false;
+
+        /// <summary>
+        /// Maximum number of consecutive <c>GetCurrentPlayer()</c> calls that may return a
+        /// transient null Entity before the Reader stops latching the last-known value and
+        /// lets null surface. Zero (or negative) disables the latch entirely.
+        /// <para>
+        /// FFXIV zeroes the local-player slot in GameObjectManager for 1–3 reads during any
+        /// zone transition while the actor table rebuilds. Latching the last-known Entity
+        /// over that window keeps <see cref="Models.ReadResults.GameStateResult.IsLoggedIn"/>
+        /// and <see cref="Models.ReadResults.CurrentPlayerResult.Entity"/> stable across the
+        /// transition. A genuine logout still surfaces once the underlying read has been null
+        /// for more than this many consecutive calls.
+        /// </para>
+        /// <para>
+        /// Default is 10. At a 5 Hz poll cadence (Chromatics' default) this gives roughly a
+        /// 2-second decay; at 10 Hz roughly 1 second. Tune to your consumer's cadence — you
+        /// want enough headroom to cover the 1–3 tick transient window without making a real
+        /// logout take noticeably long to register.
+        /// </para>
+        /// </summary>
+        public int LoggedInLatchTicks { get; set; } = 10;
     }
 }

--- a/Sharlayan/Utilities/LoggedInStateLatch.cs
+++ b/Sharlayan/Utilities/LoggedInStateLatch.cs
@@ -1,0 +1,69 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="LoggedInStateLatch.cs" company="SyndicatedLife">
+//   Copyright© 2007 - 2026 Ryan Wilson <syndicated.life@gmail.com> (https://syndicated.life/)
+//   Licensed under the MIT license. See LICENSE.md in the solution root for full license information.
+// </copyright>
+// <summary>
+//   Debounces transient null reads of the local-player ActorItem produced by
+//   <see cref="Reader.GetCurrentPlayer"/>. FFXIV briefly zeroes the local-player slot
+//   in GameObjectManager during any zone transition (teleport, instance entry, Gold
+//   Saucer mini-game entry, etc.) while the actor table rebuilds — typically 1–3
+//   poll ticks. Without latching, every downstream consumer sees Entity flip to null
+//   for that window and has to debounce it themselves. The latch is purely
+//   defensive: once it has seen a non-null Entity, it keeps returning that cached
+//   value for up to N consecutive null reads before letting null surface again, on
+//   the assumption that a sustained absence is a real logout / disconnect.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Sharlayan.Utilities {
+    using System.Threading;
+
+    using Sharlayan.Core;
+
+    internal sealed class LoggedInStateLatch {
+        private readonly int _maxConsecutiveAbsent;
+        private ActorItem _cached;
+        private int _consecutiveAbsent;
+
+        public LoggedInStateLatch(int maxConsecutiveAbsent) {
+            this._maxConsecutiveAbsent = maxConsecutiveAbsent;
+        }
+
+        // Exposed for tests; production code reads the count through Apply()'s return value.
+        internal int ConsecutiveAbsent => Volatile.Read(ref this._consecutiveAbsent);
+
+        internal ActorItem Cached => this._cached;
+
+        /// <summary>
+        /// Returns <paramref name="live"/> when it represents a present local player
+        /// (non-null Entity with non-zero ID). Otherwise returns the most recently cached
+        /// present Entity if the latch hasn't expired, falling through to <paramref name="live"/>
+        /// (typically null) once the underlying read has stayed absent for more than
+        /// <c>maxConsecutiveAbsent</c> consecutive calls.
+        /// </summary>
+        public ActorItem Apply(ActorItem live) {
+            // maxConsecutiveAbsent <= 0 disables latching entirely — handy as a kill-switch
+            // for downstream consumers that want the raw underlying read.
+            if (this._maxConsecutiveAbsent <= 0) {
+                return live;
+            }
+
+            if (live != null && live.ID != 0u) {
+                this._cached = live;
+                Volatile.Write(ref this._consecutiveAbsent, 0);
+                return live;
+            }
+
+            if (this._cached != null) {
+                int n = Interlocked.Increment(ref this._consecutiveAbsent);
+                if (n <= this._maxConsecutiveAbsent) {
+                    return this._cached;
+                }
+                this._cached = null;
+            }
+
+            return live;
+        }
+    }
+}

--- a/Sharlayan/version.props
+++ b/Sharlayan/version.props
@@ -5,7 +5,7 @@
          Patch: incremented by Claude/AI on each substantive code change to Sharlayan. -->
     <VersionMajor>9</VersionMajor>
     <VersionMinor>0</VersionMinor>
-    <VersionPatch>35</VersionPatch>
+    <VersionPatch>36</VersionPatch>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Derived version strings — do not edit these directly. -->

--- a/Sharlayan/version.props
+++ b/Sharlayan/version.props
@@ -5,7 +5,7 @@
          Patch: incremented by Claude/AI on each substantive code change to Sharlayan. -->
     <VersionMajor>9</VersionMajor>
     <VersionMinor>0</VersionMinor>
-    <VersionPatch>34</VersionPatch>
+    <VersionPatch>35</VersionPatch>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Derived version strings — do not edit these directly. -->

--- a/Sharlayan/version.props
+++ b/Sharlayan/version.props
@@ -5,7 +5,7 @@
          Patch: incremented by Claude/AI on each substantive code change to Sharlayan. -->
     <VersionMajor>9</VersionMajor>
     <VersionMinor>0</VersionMinor>
-    <VersionPatch>36</VersionPatch>
+    <VersionPatch>37</VersionPatch>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Derived version strings — do not edit these directly. -->

--- a/Sharlayan/version.props
+++ b/Sharlayan/version.props
@@ -5,7 +5,7 @@
          Patch: incremented by Claude/AI on each substantive code change to Sharlayan. -->
     <VersionMajor>9</VersionMajor>
     <VersionMinor>0</VersionMinor>
-    <VersionPatch>37</VersionPatch>
+    <VersionPatch>38</VersionPatch>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Derived version strings — do not edit these directly. -->


### PR DESCRIPTION
## Summary

Four commits ahead of `main`:

- **`1b6e29f` — chore: bump ILRepack.Lib.MSBuild.Task 2.0.44.2 → 2.0.45** (closes Dependabot #114)
- **`f646a1c` — chore: bump FCS submodule `7fc8e99ed → 5d3840d68` for FFXIV Patch 7.51**
- **`bd3f4e4` — fix: latch CurrentPlayer.Entity across FFXIV zone-transition null window**
- **`58c7542` — chore: bump FCS submodule `e8908dbe5 → 7fc8e99ed` + Lumina 7.4.0 → 7.5.0** (closes Dependabot #113)

This PR also clears the open Dependabot PRs (#113 Lumina, #114 ILRepack); Dependabot will auto-close both once this merges. No open Dependabot security alerts.

### ILRepack 2.0.45 bump (`1b6e29f`)

Routine upstream patch ("Update to ILRepack 2.0.45" — no breaking changes called out). Merged DLL size unchanged at 10980 KB; all 189 tests still pass.

### FCS 7.51 bump (`f646a1c`)

Upstream FCS landed Patch 7.51 across two commits (`560ab6a07` "7.51 partial" and `2c914a526` "7.51"), bringing struct layouts in line with the new minor patch. Other notable changes pulled in:

- `84d71d03e` removed every obsolete-marker that was previously a build warning (now a compile error). Sharlayan didn't reference any of them — build clean.
- `2e02334c7` renamed `AtkValueType.String8` → `ConstString`. Not used here.
- `e391da512` fixed `ExcelSheet` (downstream Lumina.Excel wrapper); unrelated to Sharlayan's reflection-driven offset lookups.
- `0e3388cae` / `4535876ce` / `57511682e` WKS mission + module naming churn.

Other deps on NuGet are already at latest stable: Lumina 7.5.0, Lumina.Excel 7.4.3, NLog 6.1.3, Newtonsoft.Json 13.0.4.

### Login-state latch fix (`bd3f4e4`)

FFXIV briefly zeroes the local-player slot in `GameObjectManager` for 1-3 reads during any zone transition (teleport, instance entry, Gold Saucer mini-game entry, etc.) while the actor table rebuilds. `Reader.GetCurrentPlayer()` returns `Entity = null` over that window, and `GameStateResult.IsLoggedIn` — computed inline as `cp != null && cp.ID != 0u` — flips false with it. Downstream consumers polling at 5 Hz (Chromatics' default) see a spurious _"user on title screen"_ event mid-zone followed by a _"user logging in"_ event on the next tick.

The fix is a small internal `LoggedInStateLatch` that caches the most recent present `ActorItem` and hands it back through up to N consecutive null reads, where N is configurable via `SharlayanConfiguration.LoggedInLatchTicks` (default 10 ≈ 1 s at 10 Hz / ≈ 2 s at 5 Hz; set to 0 to disable). A genuine logout still surfaces once the underlying read has stayed null past the threshold.

#### Why a tick-debounce instead of using the existing zoning signals

`GameStateResult` already exposes `IsTeleporting` and `TerritoryLoadState`, and at first glance gating the latch on those looks cleaner. In practice the territory-load state and the actor-table-rebuild window don't perfectly overlap — territory can be `Loaded` (state 2) while `GameObjectManager` is still half-built — and the conditions/gamemain keys aren't guaranteed to have scanned in degraded scan modes. A pure tick-based debounce is robust to scan-key availability and to whatever the actual transient window shape turns out to be on a given patch.

#### Public API impact

None. `CurrentPlayerResult.Entity` is still a (nullable) `ActorItem`. `GameStateResult.IsLoggedIn` is still a `bool`. `IsLoggedIn` inherits the fix transparently because it reads through `GetCurrentPlayer()`. The only new surface is `SharlayanConfiguration.LoggedInLatchTicks` — additive, defaulted.

#### Thread safety

`LoggedInStateLatch` uses `Interlocked.Increment` for the absence counter and `Volatile.Read` / `Volatile.Write` for visibility. No locks on the hot path.

#### Tests

10 new unit tests in `LoggedInStateLatchTests` cover:
- live entity passes through unchanged
- null before any live read surfaces as null
- transient null window (3 ticks) returns cached entity
- sustained absence past threshold lets null surface
- partial absence resets the counter when live returns
- zero-ID entity is treated as absent
- a new live ID replaces the cache
- threshold = 0 / negative disables the latch entirely
- repeated zone transitions each get the full latch window

### FCS / Lumina bump (`58c7542`)

- FFXIVClientStructs submodule `e8908dbe5 → 7fc8e99ed` (20+ commits, mostly struct updates).
- Lumina `7.4.0 → 7.5.0` (Lumina.Excel stays at 7.4.3, no new release at the time).

### Version

`9.0.34 → 9.0.38`.

## Test plan

- [x] `dotnet build` clean — 0 warnings, 0 errors.
- [x] `dotnet test` — 189 / 189 pass.
- [x] Debug DLLs deployed to Chromatics `Build Dependencies/Sharlayan/`.
- [ ] Eye-check in-game on 7.51: zone into Gold Saucer (or any teleport) on a Chromatics-instrumented session; confirm `Entity` and `IsLoggedIn` do not flutter over the transition window.
- [ ] Eye-check the negative case: log out via the system menu; confirm `Entity` and `IsLoggedIn` flip to absent within ~2 s at 5 Hz polling (within ~1 s at 10 Hz).
- [ ] Harness `[7]` scanner diff against a 7.51 client to confirm no `[StaticAddress]` patterns silently drifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)